### PR TITLE
[BE] auth: CustomOAuth2User 권한 NPE 해결

### DIFF
--- a/src/main/java/com/tripmoa/security/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/tripmoa/security/oauth/CustomOAuth2User.java
@@ -32,7 +32,7 @@ public class CustomOAuth2User implements OAuth2User {
     // -> 나중에 권한 시스템 만들면 여기에 추가 가능
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return java.util.List.of(() -> "ROLE_USER");
     }
 
     // Spring Security가 사용하는 사용자 식별자

--- a/src/main/java/com/tripmoa/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/tripmoa/security/oauth/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.tripmoa.security.oauth;
 
 import com.tripmoa.security.jwt.JwtTokenProvider;
+import com.tripmoa.user.entity.User;
 import com.tripmoa.user.service.AuthService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #19
- Closes #20 

---

## 🛠️ 작업 내용 (What)
- **CustomOAuth2User 권한 반환 로직 수정**: `getAuthorities()` 메서드가 `null`을 반환하던 코드를 수정하여 기본 권한(`ROLE_USER`)을 포함한 리스트를 반환하도록 변경
- **NullPointerException 방어**: Spring Security 인증 객체 생성 시 `HashSet` 초기화 과정에서 발생하는 NPE 발생 지점 제거

---

## 🧭 작업 목적 (Why)
- 소셜 로그인 성공 직후 `OAuth2LoginAuthenticationProvider`에서 사용자 권한 목록을 처리할 때, `null` 값이 전달되어 서버 에러(500)가 발생하는 버그를 해결하기 위함
- Spring Security의 보안 컨텍스트에 인증된 사용자 정보를 안전하게 저장하기 위해 유효한 권한 객체 생성이 필수적임

---

## 🧩 변경 범위
- [ ] Controller
- [x] Service (Security / OAuth2 관련 로직)
- [ ] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행 후 소셜 로그인(Google, Kakao, Naver) 버튼 클릭
- [x] `Whitelabel Error Page (status=500)` 없이 정상적으로 로그인 처리가 완료되는지 확인
- [x] 디버깅을 통해 `SecurityContext`에 `ROLE_USER` 권한이 정상 할당되었는지 확인

---

## ⚠️ 참고 사항
- 기존에 사용하시던 코드에서 `null`을 반환하던 부분은 Spring Boot 3.x 및 최신 Spring Security 환경에서 엄격하게 NPE를 유발하므로, 반드시 `List.of()` 또는 `Collections.singletonList()`를 사용해야 합니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] fix/oauth2-npe 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료