### PR TITLE
[BE] auth: JwtAuthenticationFilter 예외 처리 및 401 응답 구현

### DIFF
--- a/src/main/java/com/tripmoa/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tripmoa/security/jwt/JwtAuthenticationFilter.java
@@ -52,31 +52,54 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // "Bearer " 이후의 실제 토큰 값만 추출
             String token = header.substring(7);
 
-            // 토큰 유효성 검사
-            if (jwtTokenProvider.validateToken(token)) {
+            try {
 
-                // 토큰에서 userId 추출
-                Long userId = jwtTokenProvider.getUserId(token);
+                // 토큰 유효성 검사
+                if (jwtTokenProvider.validateToken(token)) {
 
-                // DB에서 사용자 정보 조회
-                CustomUserDetails userDetails =
-                        customUserDetailsService.loadUserById(userId);
+                    // 토큰에서 userId 추출
+                    Long userId = jwtTokenProvider.getUserId(token);
 
-                // Spring Security 인증 객체 생성
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userDetails,                    // 사용자 정보
-                                null,                           // 비밀번호 (JWT라 필요 없음)
-                                userDetails.getAuthorities()    // 권한 목록
-                        );
+                    // DB에서 사용자 정보 조회
+                    CustomUserDetails userDetails =
+                            customUserDetailsService.loadUserById(userId);
 
-                // SecurityContext에 인증 정보 저장
-                SecurityContextHolder.getContext()
-                        .setAuthentication(authentication);
+                    // Spring Security 인증 객체 생성
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails,                    // 사용자 정보
+                                    null,                           // 비밀번호 (JWT라 필요 없음)
+                                    userDetails.getAuthorities()    // 권한 목록
+                            );
+
+                    // SecurityContext에 인증 정보 저장
+                    SecurityContextHolder.getContext()
+                            .setAuthentication(authentication);
+                } else {
+                    // 토큰은 있는데 유효하지 않은 경우 (만료 등)
+                    sendErrorResponse(response, "토큰이 만료되었습니다.");
+                    return;
+                }
+            } catch (Exception e) {
+                // 필터 내에서 발생하는 모든 예외를 잡아서 401로 응답
+                sendErrorResponse(response, "인증에 실패했습니다.");
+                return;
             }
         }
 
         // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
     }
+
+    private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {
+        // 상태 코드를 401(Unauthorized)로 설정하여 프론트의 Interceptor 호출
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        // 응답 형식을 JSON으로 지정
+        response.setContentType("application/json;charset=UTF-8");
+
+        // 프론트엔드가 에러 내용을 알 수 있도록 JSON 바디 작성
+        response.getWriter().write(String.format("{\"status\": 401, \"message\": \"%s\"}", message));
+    }
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #24
- Closes #25

---

## 🛠️ 작업 내용 (What)
- `JwtAuthenticationFilter` 내 토큰 유효성 검사 로직 보완
- 토큰 만료 시 서버 내부 에러(/error)로 리다이렉트되지 않도록 즉시 `401 Unauthorized` 응답을 반환하는 `sendErrorResponse` 메서드 추가
- 프론트엔드 Axios 인터셉터가 401 코드를 정상적으로 수신하여 리프레시 토큰 로직(Silent Refresh)을 실행할 수 있는 기반 마련

---

## 🧭 작업 목적 (Why)
- 액세스 토큰 만료 시 서버가 401 대신 500 에러를 응답하여 프론트엔드에서 자동 재발급이 실패하고 사용자가 강제 로그아웃되는 현상을 해결하기 위함입니다.
- 사용자 경험(UX) 측면에서 '강제 새로고침' 없이도 세션이 안정적으로 유지되도록 보안 정책을 강화했습니다.

---

## 🧩 변경 범위
- [ ] Controller
- [ ] Service
- [ ] Domain(Entity)
- [ ] Repository
- [x] API 설계 (응답 코드 표준화)
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행 및 `ACCESS_TOKEN_VALID_TIME` 1분 설정 테스트
- [x] 브라우저 Network 탭에서 `401` 수신 후 `/api/auth/refresh` 자동 호출 확인
- [x] 새 토큰 발급 후 기존 API 요청이 성공(200)하는지 검증 완료

---

## ⚠️ 참고 사항
- 테스트 완료 후 `JwtTokenProvider`의 액세스 토큰 만료 시간을 다시 1시간(기존 설정)으로 복구하였습니다.
- 인증 실패 시 JSON 응답 포맷은 `{"status": 401, "message": "..."}` 형식을 따릅니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치(`auth/handleTokenRefresh`)에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료