### PR TITLE
[BE] feature: Mate 게시판 CRUD 기능 구현 및 Redis 기반 좋아요 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+	// Redis & WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     // 애플리케이션 자동 재시작
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/src/main/java/com/tripmoa/community/config/RedisConfig.java
+++ b/src/main/java/com/tripmoa/community/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.tripmoa.community.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("localhost", 6379);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(RedisSerializer.string()); // key
+        template.setValueSerializer(RedisSerializer.json()); // value
+        return template;
+    }
+}
+

--- a/src/main/java/com/tripmoa/community/mate/Exception/ErrorCode.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/ErrorCode.java
@@ -1,0 +1,41 @@
+package com.tripmoa.community.mate.Exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 일정 관련 (1000번대)
+    INVALID_SCHEDULE(HttpStatus.BAD_REQUEST, "M1001", "유효하지 않은 여행 일정입니다"),
+    START_DATE_BEFORE_NOW(HttpStatus.BAD_REQUEST, "M1002", "시작일은 현재 이후여야 합니다"),
+    END_DATE_BEFORE_START(HttpStatus.BAD_REQUEST, "M1003", "종료일은 시작일 이후여야 합니다"),
+
+    // 참가자 관련 (2000번대)
+    INVALID_PARTICIPANT_INFO(HttpStatus.BAD_REQUEST, "M2001", "유효하지 않은 참가자 정보입니다"),
+    CURRENT_PARTICIPANT_TOO_LOW(HttpStatus.BAD_REQUEST, "M2002", "현재 인원은 1명 이상이어야 합니다"),
+    MAX_PARTICIPANT_TOO_LOW(HttpStatus.BAD_REQUEST, "M2003", "최대 인원은 2명 이상이어야 합니다"),
+    CURRENT_EXCEEDS_MAX(HttpStatus.BAD_REQUEST, "M2004", "현재 인원이 최대 인원을 초과할 수 없습니다"),
+    ALREADY_FULLY_BOOKED(HttpStatus.BAD_REQUEST, "M2005", "이미 모집 완료 상태입니다"),
+    PARTICIPANT_FULL(HttpStatus.BAD_REQUEST, "M2006", "모집 인원이 마감되었습니다"),
+
+    // 예산 관련 (3000번대)
+    INVALID_BUDGET(HttpStatus.BAD_REQUEST, "M3001", "예산은 0 이상이어야 합니다"),
+
+    // 게시글 관련 (4000번대)
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "M4001", "게시글을 찾을 수 없습니다"),
+    UNAUTHORIZED_POST_ACCESS(HttpStatus.FORBIDDEN, "M4002", "게시글 접근 권한이 없습니다"),
+
+    // 신청서 관련 (5000번대)
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "M5001", "신청서를 찾을 수 없습니다"),
+    ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "M5002", "이미 신청한 게시글입니다"),
+    CANNOT_APPLY_OWN_POST(HttpStatus.BAD_REQUEST, "M5003", "본인 게시글에는 신청할 수 없습니다"),
+    ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "M5004", "이미 처리된 신청서입니다"),
+    UNAUTHORIZED_APPLICATION_ACCESS(HttpStatus.FORBIDDEN, "M5005", "신청서 접근 권한이 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/tripmoa/community/mate/Exception/ErrorResponse.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.tripmoa.community.mate.Exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private String code;
+    private String message;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/tripmoa/community/mate/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.tripmoa.community.mate.Exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MateException.class)
+    public ResponseEntity<ErrorResponse> handleMateException(MateException e) {
+        log.error("MateException: {}", e.getMessage(), e);
+
+        ErrorResponse response = ErrorResponse.builder()
+                .code(e.getErrorCode().getCode())
+                .message(e.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected Exception: {}", e.getMessage(), e);
+
+        ErrorResponse response = ErrorResponse.builder()
+                .code("INTERNAL_SERVER_ERROR")
+                .message("서버 내부 오류가 발생했습니다")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity
+                .status(500)
+                .body(response);
+    }
+}
+

--- a/src/main/java/com/tripmoa/community/mate/Exception/InvalidBudgetException.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/InvalidBudgetException.java
@@ -1,0 +1,13 @@
+package com.tripmoa.community.mate.Exception;
+
+public class InvalidBudgetException extends MateException {
+
+    public InvalidBudgetException(String message) {
+        super(ErrorCode.INVALID_BUDGET, message);
+    }
+
+    public InvalidBudgetException() {
+        super(ErrorCode.INVALID_BUDGET);
+    }
+}
+

--- a/src/main/java/com/tripmoa/community/mate/Exception/InvalidParticipantInfoException.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/InvalidParticipantInfoException.java
@@ -1,0 +1,28 @@
+package com.tripmoa.community.mate.Exception;
+
+public class InvalidParticipantInfoException extends MateException{
+
+    public InvalidParticipantInfoException(String message) {
+        super(ErrorCode.INVALID_PARTICIPANT_INFO, message);
+    }
+
+    public InvalidParticipantInfoException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static InvalidParticipantInfoException currentTooLow() {
+        return new InvalidParticipantInfoException(ErrorCode.CURRENT_PARTICIPANT_TOO_LOW);
+    }
+
+    public static InvalidParticipantInfoException maxTooLow() {
+        return new InvalidParticipantInfoException(ErrorCode.MAX_PARTICIPANT_TOO_LOW);
+    }
+
+    public static InvalidParticipantInfoException currentExceedsMax() {
+        return new InvalidParticipantInfoException(ErrorCode.CURRENT_EXCEEDS_MAX);
+    }
+
+    public static InvalidParticipantInfoException alreadyFullyBooked() {
+        return new InvalidParticipantInfoException(ErrorCode.ALREADY_FULLY_BOOKED);
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/Exception/InvalidScheduleException.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/InvalidScheduleException.java
@@ -1,0 +1,20 @@
+package com.tripmoa.community.mate.Exception;
+
+public class InvalidScheduleException extends MateException{
+
+    public InvalidScheduleException(String message) {
+        super(ErrorCode.INVALID_SCHEDULE, message);
+    }
+
+    public InvalidScheduleException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static InvalidScheduleException endDateBeforeStart() {
+        return new InvalidScheduleException(ErrorCode.END_DATE_BEFORE_START);
+    }
+
+    public static InvalidScheduleException startDateBeforeNow() {
+        return new InvalidScheduleException(ErrorCode.START_DATE_BEFORE_NOW);
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/Exception/MateAccessDeniedException.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/MateAccessDeniedException.java
@@ -1,0 +1,16 @@
+package com.tripmoa.community.mate.Exception;
+
+public class MateAccessDeniedException extends MateException {
+
+    public MateAccessDeniedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static MateAccessDeniedException unauthorizedPostAccess() {
+        return new MateAccessDeniedException(ErrorCode.UNAUTHORIZED_POST_ACCESS);
+    }
+
+    public static MateAccessDeniedException unauthorizedApplicationAccess() {
+        return new MateAccessDeniedException(ErrorCode.UNAUTHORIZED_APPLICATION_ACCESS);
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/Exception/MateException.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/MateException.java
@@ -1,0 +1,24 @@
+package com.tripmoa.community.mate.Exception;
+
+import lombok.Getter;
+
+@Getter
+public class MateException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public MateException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public MateException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public MateException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/Exception/MateNotFoundException.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/MateNotFoundException.java
@@ -1,0 +1,16 @@
+package com.tripmoa.community.mate.Exception;
+
+public class MateNotFoundException extends MateException {
+
+    public MateNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static MateNotFoundException postNotFound() {
+        return new MateNotFoundException(ErrorCode.POST_NOT_FOUND);
+    }
+
+    public static MateNotFoundException applicationNotFound() {
+        return new MateNotFoundException(ErrorCode.APPLICATION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/Exception/ParticipantFullException.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/ParticipantFullException.java
@@ -1,0 +1,12 @@
+package com.tripmoa.community.mate.Exception;
+
+public class ParticipantFullException extends MateException {
+
+    public ParticipantFullException(String message) {
+        super(ErrorCode.PARTICIPANT_FULL, message);
+    }
+
+    public ParticipantFullException() {
+        super(ErrorCode.PARTICIPANT_FULL);
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/controller/MateController.java
+++ b/src/main/java/com/tripmoa/community/mate/controller/MateController.java
@@ -1,0 +1,143 @@
+package com.tripmoa.community.mate.controller;
+
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.community.mate.dto.*;
+import com.tripmoa.community.mate.service.MateApplicationService;
+import com.tripmoa.community.mate.service.MateLikeService;
+import com.tripmoa.community.mate.service.MateService;
+import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+//import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mate")
+public class MateController {
+    private final MateService mateService;
+    private final MateApplicationService applyService;
+    private final MateLikeService likeService;
+
+    // 전체 메이트 포스트 조회
+    @GetMapping("/")
+    public ResponseEntity<List<MateResponse>> getMatePosts() {
+        List<MateResponse> matePosts = this.mateService.getMatePosts();
+        return ResponseEntity.ok().body(matePosts);
+    }
+
+    // 메이트 상세 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<MateResponse> getMatePostDetail(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        MateResponse matePostDetail = this.mateService.getPostsById(id, userId);
+        return ResponseEntity.ok().body(matePostDetail);
+    }
+
+    // 메이트 작성
+    @PostMapping("/")
+    public ResponseEntity<MateResponse> createMatePost(
+            @RequestBody MateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User user = userDetails.getUser();
+        MateResponse post = this.mateService.createPost(request, user);
+        return ResponseEntity.ok().body(post);
+    }
+
+    // 메이트 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteMatePost(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User user = userDetails.getUser();
+        this.mateService.deletePostById(id, user);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 내가 받은 메이트 신청서 조회
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/applications/received")
+    public ResponseEntity<List<ApplicationResponse>> getReceivedApplication(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        List<ApplicationResponse> applications = this.applyService.getReceivedApplication(userId);
+        return ResponseEntity.ok().body(applications);
+    }
+
+    // 내가 보낸 메이트 신청서 조회
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/applications/sent")
+    public ResponseEntity<List<ApplicationResponse>> getSentApplication(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        List<ApplicationResponse> applications = this.applyService.getSentApplication(userId);
+        return ResponseEntity.ok().body(applications);
+    }
+
+
+    // 특정 메이트 신청
+    @PostMapping("/{id}/apply/applicant")
+    public ResponseEntity<ApplicationResponse> applicateMatePost(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            ApplicationRequest request
+    ) {
+        User applicant = userDetails.getUser();
+        ApplicationResponse apply = this.applyService.createApply(id, request, applicant);
+        return ResponseEntity.ok().body(apply);
+    }
+
+    // 메이트 신청 승인
+    @PutMapping("/applications/{applyId}/approve")
+    public ResponseEntity<?> approve(
+            @PathVariable Long applyId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User author = userDetails.getUser();
+        ApplicationResponse approveApply = this.applyService.approveApply(applyId, author);
+        return ResponseEntity.ok().body(approveApply);
+    }
+
+    // 메이트 신청 거절
+    @PutMapping("/applications/{applyId}/reject")
+    public ResponseEntity<?> reject(
+            @PathVariable Long applyId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User author = userDetails.getUser();
+        ApplicationResponse rejectApply = this.applyService.rejectApply(applyId, author);
+        return ResponseEntity.ok().body(rejectApply);
+    }
+
+    // 좋아요 조회
+    @GetMapping("/{postId}/like")
+    public ResponseEntity<Long> getLikeCount(@PathVariable Long postId) {
+        Long likeCount = likeService.getLikeCount(postId);
+        return ResponseEntity.ok().body(likeCount);
+    }
+
+    // 좋아요 토글
+    @PostMapping("/{postId}/like")
+    public ResponseEntity<LikeResponse> toggleLike(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        LikeResponse response = likeService.toggleLike(postId, userId);
+        return ResponseEntity.ok().body(response);
+    }
+
+}

--- a/src/main/java/com/tripmoa/community/mate/domain/MateApplication.java
+++ b/src/main/java/com/tripmoa/community/mate/domain/MateApplication.java
@@ -1,0 +1,54 @@
+package com.tripmoa.community.mate.domain;
+
+import com.tripmoa.community.mate.enums.ApplyStatus;
+import com.tripmoa.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MateApplication {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private MatePost matePost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", referencedColumnName = "id")
+    private User applicant;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private ApplyStatus status;
+
+    private void validatePending() {
+        if(this.status != ApplyStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 신청서만 처리할 수 있습니다.");
+        }
+    }
+
+    public void approve() {
+        validatePending();
+        this.status = ApplyStatus.APPROVED;
+        this.matePost.incCurrentParticipant();
+    }
+
+    public void reject() {
+        validatePending();
+        this.status = ApplyStatus.REJECTED;
+    }
+
+    public boolean isAuthor(User author) {
+        return this.matePost.getUser().getId().equals(author.getId());
+    }
+
+}
+

--- a/src/main/java/com/tripmoa/community/mate/domain/MateDomain.java
+++ b/src/main/java/com/tripmoa/community/mate/domain/MateDomain.java
@@ -1,0 +1,64 @@
+package com.tripmoa.community.mate.domain;
+
+import com.tripmoa.community.mate.Exception.InvalidBudgetException;
+import com.tripmoa.community.mate.Exception.InvalidParticipantInfoException;
+import com.tripmoa.community.mate.Exception.InvalidScheduleException;
+import com.tripmoa.community.mate.Exception.ParticipantFullException;
+import com.tripmoa.user.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class MateDomain {
+
+    public void validateCreate(MatePost post) {
+        validateSchedule(post.getStartDate(), post.getEndDate());
+        validateParticipantInfo(post.getCurrentParticipant(), post.getMaxParticipant());
+        validateBudget(post.getBudget());
+    }
+
+    private void validateSchedule(LocalDate startDate, LocalDate endDate) {
+        if(endDate.isBefore(startDate)) {
+            throw InvalidScheduleException.endDateBeforeStart();
+        }
+        if(startDate.isBefore(LocalDate.now())) {
+            throw InvalidScheduleException.startDateBeforeNow();
+        }
+    }
+
+    private void validateParticipantInfo(Integer current, Integer max) {
+        if(current < 1) {
+            throw InvalidParticipantInfoException.currentTooLow();
+        }
+        if(max < 2) {
+            throw InvalidParticipantInfoException.maxTooLow();
+        }
+        if(current > max) {
+            throw InvalidParticipantInfoException.currentExceedsMax();
+        }
+        if(current.equals(max)) {
+            throw InvalidParticipantInfoException.alreadyFullyBooked();
+        }
+    }
+
+    private void validateBudget(Integer budget) {
+        if(budget < 0) {
+            throw new InvalidBudgetException();
+        }
+    }
+
+    public boolean isFullyBooked(MatePost post) {
+        return post.getCurrentParticipant()>=post.getMaxParticipant();
+    }
+
+    public void validateApply(MatePost post) {
+        if(isFullyBooked(post)) {
+            throw new ParticipantFullException();
+        }
+    }
+
+    public boolean isAuthor(MatePost post, User user) {
+        return post.getUser().getId().equals(user.getId());
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/domain/MatePost.java
+++ b/src/main/java/com/tripmoa/community/mate/domain/MatePost.java
@@ -1,0 +1,93 @@
+package com.tripmoa.community.mate.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.tripmoa.community.mate.enums.AgeGroup;
+import com.tripmoa.community.mate.enums.GenderPreference;
+import com.tripmoa.community.mate.enums.Transport;
+import com.tripmoa.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MatePost {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    @Column(length = 500)
+    private String content;
+
+    // 도착지
+    @Column(length = 100, nullable = false)
+    private String destination;
+
+    // 출발 일정 - 도착 일정
+    @Column(nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate startDate;
+    @Column(nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate endDate;
+
+    // 여행 참여인원
+    @Column(nullable = false)
+    private Integer currentParticipant;
+    @Column(nullable = false)
+    private Integer maxParticipant;
+
+    // 예산
+    @Column(nullable = false)
+    private Integer budget;
+
+    // 이동수단
+    @Enumerated(EnumType.STRING)
+    private Transport transport;
+
+    // 성별 선호
+    @Enumerated(EnumType.STRING)
+    private GenderPreference genderPreference;
+
+    // 나이 선호
+    @Enumerated(EnumType.STRING)
+    private AgeGroup ageGroup;
+
+//    @Enumerated(EnumType.STRING)
+//    private Set<Tag> tags;
+
+    // 조회수, 좋아요
+    @Column
+    @Builder.Default
+    private Long likesCount = 0L;
+    @Column
+    @Builder.Default
+    private Long viewsCount = 0L;
+
+    @Column(nullable = false)
+    private LocalDateTime  createdAt;
+
+
+
+    public void incViewsCount() {this.viewsCount++;}
+    public void incLikesCount() {this.likesCount++;}
+    public void decLikesCount() {
+        if(this.likesCount>0) {
+            this.likesCount--;
+        }
+    }
+
+    public void incCurrentParticipant() {this.currentParticipant++;}
+    public void decCurrentParticipant() {this.currentParticipant--;}
+
+}

--- a/src/main/java/com/tripmoa/community/mate/dto/ApplicationRequest.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/ApplicationRequest.java
@@ -1,0 +1,21 @@
+package com.tripmoa.community.mate.dto;
+
+import com.tripmoa.community.mate.domain.MateApplication;
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.community.mate.enums.ApplyStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ApplicationRequest {
+
+    @NotBlank(message = "신청 내용은 필수입니다")
+    @Size(max = 500, message = "500자를 초과할 수 없습니다")
+    private String content;
+
+}

--- a/src/main/java/com/tripmoa/community/mate/dto/ApplicationResponse.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/ApplicationResponse.java
@@ -1,0 +1,32 @@
+package com.tripmoa.community.mate.dto;
+
+import com.tripmoa.community.mate.domain.MateApplication;
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.community.mate.enums.ApplyStatus;
+import com.tripmoa.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class ApplicationResponse {
+
+    private User applicant;
+    private MatePost matePost;
+    private ApplyStatus status;
+    private String content;
+
+    public static ApplicationResponse from(MateApplication application) {
+        return ApplicationResponse.builder()
+                .applicant(application.getApplicant())
+                .matePost(application.getMatePost())
+                .status(application.getStatus())
+                .content(application.getContent())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tripmoa/community/mate/dto/AuthorDto.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/AuthorDto.java
@@ -1,0 +1,48 @@
+package com.tripmoa.community.mate.dto;
+
+import com.tripmoa.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AuthorDto {
+    private Long id;
+    private String nickname;
+    private String email;
+    private String profileImage;
+    private String avatarEmoji;
+    private String avatarColor;
+    private String gender;
+    private Integer age;
+    private List<String> travelStyles;
+
+    public static AuthorDto from(User user) {
+        // 나이 계산
+        Integer age = null;
+        if (user.getBirthDate() != null) {
+            age = LocalDate.now().getYear() - user.getBirthDate().getYear();
+        }
+
+        return AuthorDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImage(user.getProfileImage())
+                .avatarEmoji(user.getAvatarEmoji())
+                .avatarColor(user.getAvatarColor())
+                .gender(user.getGender() != null ? user.getGender().name() : null)
+                .age(age)
+//                .travelStyles(
+//                        user.getTravelStyles().stream()
+//                                .map(userStyle -> userStyle.getStyle().getName())
+//                                .toList()
+//                )
+                .build();
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/dto/LikeResponse.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/LikeResponse.java
@@ -1,0 +1,11 @@
+package com.tripmoa.community.mate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeResponse {
+    private boolean liked;
+    private long count;
+}

--- a/src/main/java/com/tripmoa/community/mate/dto/MateRequest.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/MateRequest.java
@@ -1,0 +1,79 @@
+package com.tripmoa.community.mate.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.community.mate.enums.AgeGroup;
+import com.tripmoa.community.mate.enums.GenderPreference;
+import com.tripmoa.community.mate.enums.Transport;
+import com.tripmoa.user.entity.User;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MateRequest {
+
+    @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 500, message = "내용은 500자를 초과할 수 없습니다")
+    private String content;
+
+    @NotBlank(message = "도착지는 필수입니다")
+    @Size(max = 100, message = "도착지는 100자를 초과할 수 없습니다")
+    private String destination;
+
+    @NotNull(message = "출발 날짜는 필수입니다")
+    @Future(message = "출발 날짜는 미래여야 합니다")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @NotNull(message = "도착 날짜는 필수입니다")
+    @Future(message = "도착 날짜는 미래여야 합니다")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    @NotNull(message = "현재 참여 인원은 필수입니다")
+    @Min(value = 1, message = "최소 1명 이상이어야 합니다")
+    private Integer currentParticipant;
+
+    @NotNull(message = "최대 참여 인원은 필수입니다")
+    @Min(value = 2, message = "최소 2명 이상이어야 합니다")
+    @Max(value = 10, message = "최대 10명까지 가능합니다")
+    private Integer maxParticipant;
+
+    @NotNull(message = "예산은 필수입니다")
+    @Min(value = 0, message = "예산은 0 이상이어야 합니다")
+    private Integer budget;
+
+    @NotNull(message = "이동수단은 필수입니다")
+    private Transport transport;
+
+    private GenderPreference genderPreference;
+
+    private AgeGroup ageGroup;
+
+    public MatePost toEntity(User user) {
+        return MatePost.builder()
+                .user(user)
+                .content(this.content)
+                .destination(this.destination)
+                .startDate(this.startDate)
+                .endDate(this.endDate)
+                .currentParticipant(this.currentParticipant)
+                .maxParticipant(this.maxParticipant)
+                .budget(this.budget)
+                .transport(this.transport)
+                .genderPreference(this.genderPreference)
+                .ageGroup(this.ageGroup)
+                .likesCount(0L)
+                .viewsCount(0L)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/dto/MateResponse.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/MateResponse.java
@@ -1,0 +1,57 @@
+package com.tripmoa.community.mate.dto;
+
+import com.tripmoa.community.mate.enums.AgeGroup;
+import com.tripmoa.community.mate.enums.GenderPreference;
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.community.mate.enums.Transport;
+import com.tripmoa.user.entity.User;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MateResponse {
+    private Long id;
+    private String content;
+    private String destination;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer currentParticipant;
+    private Integer maxParticipant;
+    private Integer budget;
+    private Transport transport;
+    private GenderPreference genderPreference;
+    private AgeGroup ageGroup;
+//    private Set<Tag> tags;
+    private Long likesCount;
+    private Long viewsCount;
+    private LocalDateTime createdAt;
+    private boolean isLiked;
+
+    private AuthorDto author;
+
+    public static MateResponse from(MatePost matePost) {
+        return MateResponse.builder()
+                .id(matePost.getId())
+                .content(matePost.getContent())
+                .destination(matePost.getDestination())
+                .startDate(matePost.getStartDate())
+                .endDate(matePost.getEndDate())
+                .currentParticipant(matePost.getCurrentParticipant())
+                .maxParticipant(matePost.getMaxParticipant())
+                .budget(matePost.getBudget())
+                .transport(matePost.getTransport())
+                .genderPreference(matePost.getGenderPreference())
+                .ageGroup(matePost.getAgeGroup())
+                .likesCount(matePost.getLikesCount())
+                .viewsCount(matePost.getViewsCount())
+                .createdAt(matePost.getCreatedAt())
+                .author(AuthorDto.from(matePost.getUser()))
+                .build();
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/enums/AgeGroup.java
+++ b/src/main/java/com/tripmoa/community/mate/enums/AgeGroup.java
@@ -1,0 +1,51 @@
+package com.tripmoa.community.mate.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AgeGroup {
+    ALL("전체", "all"),
+    TWENTIES("20대", "20s"),
+    THIRTIES("30대", "30s"),
+    FORTIES("40대", "40s"),
+    FIFTIES_PLUS("50대 이상", "50s+");
+
+    private final String korean;
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static AgeGroup fromValue(String input) {
+        if (input == null) {
+            return ALL;
+        }
+
+        for(AgeGroup ageGroup : values()) {
+            if(ageGroup.value.equalsIgnoreCase(input)) {
+                return ageGroup;
+            }
+        }
+
+        for(AgeGroup ageGroup : values()) {
+            if(ageGroup.korean.equals(input)) {
+                return ageGroup;
+            }
+        }
+
+        throw new IllegalArgumentException(input + " is not a valid AgeGroup");
+    }
+
+    public static AgeGroup fromKorean(String korean) {
+        for(AgeGroup ageGroup : values()) {
+            if(ageGroup.korean.equals(korean)) {
+                return ageGroup;
+            }
+        }
+        throw new IllegalArgumentException(korean + " is not a valid AgeGroup");
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/enums/ApplyStatus.java
+++ b/src/main/java/com/tripmoa/community/mate/enums/ApplyStatus.java
@@ -1,0 +1,38 @@
+package com.tripmoa.community.mate.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApplyStatus {
+    PENDING("신청 대기", "pending"),
+    APPROVED("승인됨", "approved"),
+    REJECTED("거절됨", "rejected");
+
+    private final String korean;
+
+    @JsonValue
+    private final String value;
+
+    public static ApplyStatus fromValue(String value) {
+        for(ApplyStatus status : values()) {
+            if(status.value.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("invalid status " + value);
+    }
+
+    public static ApplyStatus fromKorean(String korean) {
+        for(ApplyStatus status : values()) {
+            if(status.korean.equalsIgnoreCase(korean)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("invalid status " + korean);
+    }
+
+}
+

--- a/src/main/java/com/tripmoa/community/mate/enums/GenderPreference.java
+++ b/src/main/java/com/tripmoa/community/mate/enums/GenderPreference.java
@@ -1,0 +1,42 @@
+package com.tripmoa.community.mate.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GenderPreference {
+    ANY("무관", "any"),
+    MALE("남성", "male"),
+    FEMALE("여성", "female");
+
+    private final String korean;
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static GenderPreference fromValue(String input) {
+        if (input == null) {
+            return ANY;
+        }
+
+        // 영문 값으로 찾기
+        for(GenderPreference gender : values()) {
+            if(gender.value.equalsIgnoreCase(input)) {
+                return gender;
+            }
+        }
+
+        // 한글 값으로 찾기
+        for(GenderPreference gender : values()) {
+            if(gender.korean.equals(input)) {
+                return gender;
+            }
+        }
+
+        throw new IllegalArgumentException(input + " is not a valid GenderPreference");
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/enums/Transport.java
+++ b/src/main/java/com/tripmoa/community/mate/enums/Transport.java
@@ -1,0 +1,46 @@
+package com.tripmoa.community.mate.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Transport {
+    BUS("버스", "bus"),
+    AIRPLANE("비행기", "airplane"),
+    MY_CAR("자차", "mycar"),
+    RENTAL_CAR("렌트카", "rentalcar"),
+    TAXI("택시", "taxi"),
+    TRAIN("기차", "train"),
+    WALK("도보", "walk");
+
+    private final String korean;
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static Transport fromValue(String input) {
+        if (input == null) {
+            return MY_CAR;
+        }
+
+        // 영문 값으로 찾기
+        for(Transport transport : values()) {
+            if(transport.value.equalsIgnoreCase(input)) {
+                return transport;
+            }
+        }
+
+        // 한글 값으로 찾기
+        for(Transport transport : values()) {
+            if(transport.korean.equals(input)) {
+                return transport;
+            }
+        }
+
+        throw new IllegalArgumentException(input + " is not a valid Transport");
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/repository/ApplicationRepository.java
+++ b/src/main/java/com/tripmoa/community/mate/repository/ApplicationRepository.java
@@ -1,0 +1,23 @@
+package com.tripmoa.community.mate.repository;
+
+import com.tripmoa.community.mate.domain.MateApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ApplicationRepository extends JpaRepository<MateApplication, Long> {
+
+    @Query("SELECT a FROM MateApplication a " +
+            "JOIN FETCH a.matePost p " +
+            "WHERE p.user.id = :ownerId")
+    List<MateApplication> findByOwnerId(@Param("ownerId") Long ownerId);
+
+    @Query("SELECT a FROM MateApplication a " +
+            "JOIN FETCH a.applicant " +
+            "WHERE a.applicant.id = :applicantId")
+    List<MateApplication> findByApplicantId(Long applicantId);
+}

--- a/src/main/java/com/tripmoa/community/mate/repository/LikeRepositoryCustom.java
+++ b/src/main/java/com/tripmoa/community/mate/repository/LikeRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.tripmoa.community.mate.repository;
+
+public interface LikeRepositoryCustom {
+    void updateLikeCount(Long postId, Long count);
+}

--- a/src/main/java/com/tripmoa/community/mate/repository/LikeRepositoryCustomImpl.java
+++ b/src/main/java/com/tripmoa/community/mate/repository/LikeRepositoryCustomImpl.java
@@ -1,0 +1,23 @@
+package com.tripmoa.community.mate.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeRepositoryCustomImpl implements LikeRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    @Transactional
+    public void updateLikeCount(Long postId, Long Count) {
+        em.createQuery("UPDATE MatePost p SET p.likesCount = :count WHERE p.id = :postId")
+                .setParameter("count", Count)
+                .setParameter("postId", postId)
+                .executeUpdate();
+    }
+
+}

--- a/src/main/java/com/tripmoa/community/mate/repository/MateRepository.java
+++ b/src/main/java/com/tripmoa/community/mate/repository/MateRepository.java
@@ -1,0 +1,28 @@
+package com.tripmoa.community.mate.repository;
+
+import com.tripmoa.community.mate.domain.MatePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MateRepository extends JpaRepository <MatePost, Long>, LikeRepositoryCustom{
+
+    @Query("SELECT p.likesCount FROM MatePost p WHERE p.id = :postId")
+    Long countLikes(@Param("postId") Long postId);
+
+    @Query("SELECT m FROM MatePost m JOIN FETCH m.user")
+    List<MatePost> findAllWithUser();
+
+    @Query("SELECT m FROM MatePost m JOIN FETCH m.user WHERE m.id = :id")
+    Optional<MatePost> findByIdWithUser(Long id);
+
+    @Modifying
+    @Query("UPDATE MatePost m SET m.viewsCount = m.viewsCount + 1 WHERE m.id = :postId")
+    void updateViewsCount(@Param("postId") Long postId);
+}

--- a/src/main/java/com/tripmoa/community/mate/service/LikeSyncScheduler.java
+++ b/src/main/java/com/tripmoa/community/mate/service/LikeSyncScheduler.java
@@ -1,0 +1,52 @@
+package com.tripmoa.community.mate.service;
+
+import com.tripmoa.community.mate.repository.MateRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LikeSyncScheduler {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final MateRepository mateRepository;
+
+    @Scheduled(fixedRate = 1000 * 60 * 5)
+    public void syncLikesToDB() {
+
+        ScanOptions options = ScanOptions.scanOptions()
+                .match("post:*:likeCount")
+                .count(100)
+                .build();
+
+        try (Cursor<byte[]> cursor = redisTemplate.getConnectionFactory()
+                .getConnection()
+                .scan(options)) {
+            while (cursor.hasNext()) {
+                String key = new String(cursor.next());
+                Long postId = extractPostId(key);
+
+                String countStr = (String) redisTemplate.opsForValue().get(key);
+                if (countStr == null) continue;
+
+                Long likeCount = Long.valueOf(countStr);
+
+                mateRepository.updateLikeCount(postId, likeCount);
+
+                log.info("Synced Redis to DB | postId={}, count={}", postId, likeCount);
+            }
+        }
+
+    }
+
+    private Long extractPostId(String key) {
+        return Long.valueOf(key.split(":")[1]);
+    }
+
+}

--- a/src/main/java/com/tripmoa/community/mate/service/MateApplicationService.java
+++ b/src/main/java/com/tripmoa/community/mate/service/MateApplicationService.java
@@ -1,0 +1,89 @@
+package com.tripmoa.community.mate.service;
+
+import com.tripmoa.community.mate.domain.MateApplication;
+import com.tripmoa.community.mate.domain.MateDomain;
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.community.mate.dto.ApplicationRequest;
+import com.tripmoa.community.mate.dto.ApplicationResponse;
+import com.tripmoa.community.mate.dto.MateResponse;
+import com.tripmoa.community.mate.enums.ApplyStatus;
+import com.tripmoa.community.mate.repository.ApplicationRepository;
+import com.tripmoa.community.mate.repository.MateRepository;
+import com.tripmoa.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MateApplicationService {
+
+    private final MateDomain domain;
+    private final MateRepository mateRepository;
+    private final ApplicationRepository applyRepository;
+
+    public List<ApplicationResponse> getReceivedApplication(Long ownerId) {
+        List<MateApplication> applications  = this.applyRepository.findByOwnerId(ownerId); // 내가 쓴 포스트로 조회
+        return applications.stream()
+                .map(ApplicationResponse::from)
+                .toList();
+    }
+
+    public List<ApplicationResponse> getSentApplication(Long applicantId) {
+        List<MateApplication> applications  = this.applyRepository.findByApplicantId(applicantId); // 내가 쓴 신청서로 조회
+        return applications.stream()
+                .map(ApplicationResponse::from)
+                .toList();
+    }
+
+
+    public ApplicationResponse createApply(Long postId, ApplicationRequest request, User applicant) {
+        MatePost post = this.mateRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("Post NOT Found"));
+
+        MateApplication application = MateApplication.builder()
+                .matePost(post)
+                .applicant(applicant)
+                .content(request.getContent())
+                .status(ApplyStatus.PENDING)
+                .build();
+
+        applyRepository.save(application);
+
+        return ApplicationResponse.from(application);
+    }
+
+    @Transactional
+    public ApplicationResponse approveApply(Long applyPostId, User author) {
+        MateApplication application = this.applyRepository.findById(applyPostId)
+                .orElseThrow(() -> new RuntimeException("Application NOT Found"));
+
+        if(!application.isAuthor(author)) {
+            throw new IllegalStateException("작성자만 승인할 수 있습니다.");
+        }
+
+        application.approve();
+        return ApplicationResponse.from(application);
+    }
+
+    @Transactional
+    public ApplicationResponse rejectApply(Long applyPostId, User author) {
+        MateApplication application = this.applyRepository.findById(applyPostId)
+                .orElseThrow(() -> new RuntimeException("Application NOT Found"));
+
+                if(!application.isAuthor(author)) {
+                    throw new IllegalStateException("작성자만 승인할 수 있습니다.");
+                }
+
+        application.reject();
+        return ApplicationResponse.from(application);
+
+
+    }
+
+}

--- a/src/main/java/com/tripmoa/community/mate/service/MateLikeService.java
+++ b/src/main/java/com/tripmoa/community/mate/service/MateLikeService.java
@@ -1,0 +1,60 @@
+package com.tripmoa.community.mate.service;
+
+import com.tripmoa.community.mate.dto.LikeResponse;
+import com.tripmoa.community.mate.repository.MateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.BoundSetOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MateLikeService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final MateRepository mateRepository;
+
+    public LikeResponse toggleLike(Long postId, Long userId) {
+
+        String likeUserKey = "post:" + postId + ":likeUsers";
+        String likeCountKey = "post:" + postId + ":likeCount";
+        String userIdStr = String.valueOf(userId);
+
+        BoundSetOperations<String, Object> setOps =  redisTemplate.boundSetOps(likeUserKey);
+        boolean alreadyLiked = Boolean.TRUE.equals(setOps.isMember(userIdStr));
+
+        if(alreadyLiked) {
+            setOps.remove(userIdStr);
+            Long count = redisTemplate.opsForValue().decrement(likeCountKey);
+            return new LikeResponse(false, count);
+        } else {
+            setOps.add(userIdStr);
+            Long count = redisTemplate.opsForValue().increment(likeCountKey);
+            return new LikeResponse(true, count);
+        }
+    }
+
+    public Long getLikeCount(Long postId) {
+        String likeCountKey = "post:" + postId + ":likeCount";
+        Object value = redisTemplate.opsForValue().get(likeCountKey);
+
+        if (value == null) {
+            Long fromDB = mateRepository.findById(postId)
+                    .map(post -> post.getLikesCount())
+                    .orElse(0L);
+
+            redisTemplate.opsForValue().set(likeCountKey, fromDB);
+            return fromDB;
+        }
+
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+
+        try {
+            return Long.valueOf(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/service/MateService.java
+++ b/src/main/java/com/tripmoa/community/mate/service/MateService.java
@@ -1,0 +1,89 @@
+package com.tripmoa.community.mate.service;
+
+import com.tripmoa.community.mate.domain.MateApplication;
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.community.mate.domain.MateDomain;
+import com.tripmoa.community.mate.dto.MateRequest;
+import com.tripmoa.community.mate.dto.MateResponse;
+import com.tripmoa.community.mate.repository.MateRepository;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MateService {
+    private final MateRepository mateRepository;
+    private final UserRepository userRepository;
+    private final MateLikeService likeService;
+    private final MateDomain domain;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public List<MateResponse> getMatePosts() {
+        List<MatePost> matePosts = mateRepository.findAllWithUser();
+        return matePosts.stream()
+                .map(post -> {
+                    MateResponse response = MateResponse.from(post);
+                    Long likeCount = likeService.getLikeCount(post.getId());
+                    response.setLikesCount(likeCount);
+                    return response;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public MateResponse getPostsById(Long id, Long userId) {
+        MatePost matePostDetail = mateRepository.findByIdWithUser(id)
+                .orElseThrow(() -> new RuntimeException("Post NOT Found"));
+        String redisKey = "view:mate:" + id + ":user:" + userId;
+        Boolean isFirstView = redisTemplate
+                .opsForValue()
+                .setIfAbsent(redisKey, "true", Duration.ofHours(24));
+
+        if (Boolean.TRUE.equals(isFirstView)) {
+            mateRepository.updateViewsCount(id);
+        }
+
+        Long likeCount = likeService.getLikeCount(id);
+        boolean isLiked = false;
+        String likeUserKey = "post:" + id + ":likeUsers";
+        isLiked = Boolean.TRUE.equals(
+                redisTemplate
+                        .boundSetOps(likeUserKey)
+                        .isMember(String.valueOf(userId)));
+
+        MateResponse response = MateResponse.from(matePostDetail);
+        response.setLikesCount(likeCount);
+        response.setLiked(isLiked);
+
+        return response;
+    }
+
+    @Transactional
+    public MateResponse createPost(MateRequest request, User user) {
+        MatePost post = request.toEntity(user);
+
+        domain.validateCreate(post);
+        mateRepository.save(post);
+        return MateResponse.from(post);
+    }
+
+    public void deletePostById(Long id, User user) {
+        MatePost post = this.mateRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Post NOT Found"));
+
+        if(!domain.isAuthor(post, user)) {
+            throw new IllegalStateException("작성자만 삭제할 수 있습니다.");
+        }
+        mateRepository.deleteById(id);
+    }
+
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #28 

---

## 🛠️ 작업 내용 (What)
- **Mate 모집 게시글 CRUD API 개발**
  - 게시글 등록(`POST`), 상세 조회(`GET`), 목록 페이징 조회 구현
- **Enum 데이터 바인딩 및 역직렬화 최적화**
  - `Transport`, `AgeGroup`, `GenderPreference` 엔티티에 `@JsonValue` 및 `@JsonCreator` 적용
  - 프론트엔드 전송 값과 서버 Enum 상수 간의 불일치 문제 해결
- **Redis 기반 좋아요(Like) 기능 도입**
  - 게시글별 좋아요 수를 Redis에서 캐싱 및 증감 처리하여 DB 부하 최적화
  - `MateLikeService` 구현 및 Redis 데이터 타입 캐스팅 오류 수정
- **날짜 정합성 보정 로직 적용**
  - `LocalDate` 타입을 사용하여 클라이언트-서버 간 시간대(KST/UTC) 오차 해결
- **커스텀 예외 처리**

---

## 🧭 작업 목적 (Why)
- **성능 향상**: 빈번한 수정이 발생하는 '좋아요' 데이터를 메모리 DB인 Redis에서 관리함으로써 RDBMS의 I/O 비용 절감
- **데이터 정합성**: 프론트엔드 옵션값과 백엔드 Enum 규격(`mycar`, `20s` 등)을 일치시켜 데이터 저장 시 발생하는 에러 방지
- **사용자 경험**: 날짜 데이터 전송 시 하루 전으로 저장되는 시간대 오류를 해결하여 정확한 여행 일정 정보 제공

---

## 🧩 변경 범위
- [x] Controller (`MateController`)
- [x] Service (`MateService`, `MateLikeService`)
- [x] Domain(Entity) (`MatePost`, Enum 3종)
- [x] Repository (`MatePostRepository`)
- [x] Infrastructure (`RedisConfig`, `RedisTemplate`)
- [x] API 설계
- [x] DB 스키마

---

## 🧪 테스트 방법
- [x] **로컬 서버 실행**: Spring Boot 및 Redis 컨테이너(Port: 6379) 정상 기동 확인
- [x] **API 테스트 (Postman)**: 게시글 등록 및 상세 조회 시 Enum/날짜 데이터 정상 출력 확인
- [x] **Redis 검증**: `redis-cli`를 통해 좋아요 카운트 캐싱 및 정수값 증감 확인
- [x] **예외 테스트**: 존재하지 않는 Enum 값 전송 시 `IllegalArgumentException` 처리 확인

---

## ⚠️ 참고 사항
- **Redis 의존성**: 로컬 테스트 시 Redis 서버가 활성화되어 있어야 기능이 정상 동작합니다.
- **캐스팅 에러 수정**: `MateLikeService`에서 `Integer`를 `String`으로 캐스팅하던 문제를 `String.valueOf()` 방식으로 변경하여 안정성을 확보했습니다.
- **프론트엔드 연동**: 날짜 데이터는 `YYYY-MM-DD` 문자열 형식을 권장하며, Enum 값은 소문자 규격을 사용해야 합니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [ ] feature/mateCRUD 브랜치에서 작업 완료
- [x] 불필요한 로그(`System.out.println`) 제거
- [ ] API 명세 변경 사항 팀 내 공유 완료
