### PR TITLE
[BE] feature: 네이버 OCR API 연동 및 데이터 송수신 구현

### DIFF
--- a/src/main/java/com/tripmoa/expense/ExController.java
+++ b/src/main/java/com/tripmoa/expense/ExController.java
@@ -1,0 +1,23 @@
+package com.tripmoa.expense;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class ExController {
+
+    private final ExService exService;
+
+    @PostMapping("/api/v1/ocr/connect")
+    public ResponseEntity<Map<String, Object>> testOcrConnection(@RequestParam("file") MultipartFile file) {
+        return ResponseEntity.ok(exService.callOcrApi(file));
+    }
+
+}

--- a/src/main/java/com/tripmoa/expense/ExService.java
+++ b/src/main/java/com/tripmoa/expense/ExService.java
@@ -1,0 +1,147 @@
+package com.tripmoa.expense;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ExService {
+
+    @Value("${naver.ocr.invoke-url}")
+    private String invokeUrl;
+
+    @Value("${naver.ocr.secret-key}")
+    private String secretKey;
+
+    @Value("${naver.ocr.api-gateway-key-id:}")
+    private String apiGatewayKeyId;
+
+    @Value("${naver.ocr.api-gateway-key:}")
+    private String apiGatewayKey;
+
+    @Value("${naver.ocr.domain-id:}")
+    private String domainId;
+
+    @Value("${naver.ocr.signature:}")
+    private String signature;
+
+    @Value("${naver.ocr.path:}")
+    private String path;
+
+    private final RestTemplate restTemplate;
+
+    public Map<String, Object> callOcrApi(MultipartFile file) {
+        try {
+            // 인코딩 이슈 방지
+            DefaultUriBuilderFactory uriFactory = new DefaultUriBuilderFactory();
+            uriFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+            restTemplate.setUriTemplateHandler(uriFactory);
+
+            // RestTemplate 기본 에러 핸들러가 body를 숨기는 경우가 있어 직접 로깅
+            restTemplate.setErrorHandler(new DefaultResponseErrorHandler());
+
+            // 최종 URL 만들기
+            String url = buildFinalUrl();
+
+            // 헤더
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+            // OCR Secret
+            headers.set("X-OCR-SECRET", secretKey);
+
+            // Usage Plan에서 API Key 강제를 걸었거나, 키가 필요한 상품이면 추가
+            if (!isBlank(apiGatewayKeyId) && !isBlank(apiGatewayKey)) {
+                headers.set("X-NCP-APIGW-API-KEY-ID", apiGatewayKeyId);
+                headers.set("X-NCP-APIGW-API-KEY", apiGatewayKey);
+            }
+
+            // multipart body: file + message(JSON 문자열)
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+
+            // file 파트
+            body.add("file", new ByteArrayResource(file.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return file.getOriginalFilename() == null ? "upload.jpg" : file.getOriginalFilename();
+                }
+            });
+
+            // message 파트 (템플릿 OCR 공통 형식)
+            String ext = getExt(file.getOriginalFilename());
+            String messageJson = buildMessageJson(ext);
+
+            body.add("message", messageJson);
+
+            HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+            // 호출
+            ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, requestEntity, Map.class);
+            return (Map<String, Object>) response.getBody();
+
+        } catch (HttpStatusCodeException e) {
+            throw new RuntimeException("네이버 OCR 에러: " + e.getResponseBodyAsString());
+        } catch (Exception e) {
+            throw new RuntimeException("OCR 호출 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    private String buildFinalUrl() {
+        if (isBlank(domainId) || isBlank(signature) || isBlank(path)) {
+            return invokeUrl;
+        }
+
+        String base = invokeUrl;
+        if (base.endsWith("/")) base = base.substring(0, base.length() - 1);
+
+        String p = path;
+        if (p.startsWith("/")) p = p.substring(1);
+
+        return base + "/" + domainId + "/" + signature + "/" + p;
+    }
+
+    private String buildMessageJson(String format) {
+
+        return """
+        {
+          "version": "V2",
+          "requestId": "%s",
+          "timestamp": %d,
+          "images": [
+            {
+              "format": "%s",
+              "name": "receipt_test"
+            }
+          ]
+        }
+        """.formatted(UUID.randomUUID(), System.currentTimeMillis(), format);
+    }
+
+    private String getExt(String filename) {
+        if (filename == null) return "jpg";
+        int idx = filename.lastIndexOf('.');
+        if (idx < 0) return "jpg";
+        String ext = filename.substring(idx + 1).toLowerCase();
+        if ("jpeg".equals(ext)) return "jpg";
+        return ext;
+    }
+
+    private boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/tripmoa/global/ExceptionHandler.java
+++ b/src/main/java/com/tripmoa/global/ExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.tripmoa.global;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// 외부 API(네이버 OCR) 호출 시 발생할 수 있는 오류나 파일 업로드 관련 예외 처리
+
+@RestControllerAdvice
+public class ExceptionHandler {
+
+    // OCR 호출 중 발생하는 예외 처리
+    @org.springframework.web.bind.annotation.ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("error", "OCR_PROCESS_ERROR");
+        // e.getMessage()에 네이버가 준 "bad request" 상세 내용이 담기도록 유도
+        response.put("message", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    // 파일 용량 초과 예외 처리
+    @org.springframework.web.bind.annotation.ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<Map<String, String>> handleMaxSizeException(MaxUploadSizeExceededException e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("error", "FILE_SIZE_EXCEEDED");
+        response.put("message", "파일 용량이 너무 큽니다. (최대 10MB)");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+}

--- a/src/main/java/com/tripmoa/global/RestConfig.java
+++ b/src/main/java/com/tripmoa/global/RestConfig.java
@@ -1,0 +1,19 @@
+package com.tripmoa.global;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+// RestTemplate Config 클래스
+@Configuration
+public class RestConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        SimpleClientHttpRequestFactory f = new SimpleClientHttpRequestFactory();
+        f.setConnectTimeout(5000);
+        f.setReadTimeout(30000);
+        return new RestTemplate(f);
+    }
+}

--- a/src/main/java/com/tripmoa/security/config/SecurityConfig.java
+++ b/src/main/java/com/tripmoa/security/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
                         .requestMatchers("/oauth2/**", "/login/oauth2/**", "/api/auth/**").permitAll()
 
                         // 비로그인 사용자도 볼 수 있는 데이터 (Public API)
-                        .requestMatchers("/api/travelstory/**", "/api/mate/**").permitAll()
+                        .requestMatchers("/api/travelstory/**", "/api/mate/**", "/api/v1/ocr/connect").permitAll()
 
                         // 서버 상태 확인 및 에러 페이지 : 모두 허용
                         .requestMatchers("/actuator/health", "/error", "/favicon.ico").permitAll()


### PR DESCRIPTION
## 🔗 관련 이슈

* Closes #27

---

## 🛠️ 작업 내용 (What)

* 네이버 CLOVA OCR Template 서비스 및 API Gateway 연동 구현
* 영수증 이미지 업로드 시 OCR 요청을 전송하는 API Endpoint 추가 (`POST /api/v1/ocr/connect`)
* multipart/form-data 형식으로 이미지 파일 및 message JSON 구성하여 OCR API 호출
* OCR Secret Key 및 API Gateway Key 인증 처리 로직 구현
* OCR 응답(JSON) 수신 및 클라이언트로 반환 기능 구현
* Spring Security에서 `/api/v1/ocr/connect` Endpoint에 대해 인증 없이 접근 가능하도록 permitAll 설정 추가
* Postman을 통한 OCR 요청 및 응답 정상 동작 확인

---

## 🧭 작업 목적 (Why)

여행 경비 정산 시스템에서 영수증 이미지를 업로드하면 OCR을 통해 상호명, 결제일, 결제 금액, 결제 방법 등의 정보를 자동으로 추출하여 사용자 입력을 보조하기 위함.

OCR 기반 자동 입력 기능의 기반을 구축하고, 향후 Expense 생성 및 DB 저장 기능과 연동하기 위한 사전 작업.

---

## 🧩 변경 범위

* [x] ExController 

  * `/api/v1/ocr/connect` Endpoint 구현

* [x] ExService 

  * CLOVA OCR API Gateway 호출 로직 구현
  * multipart 요청 구성 및 OCR 응답 수신 처리

* [ ] Domain(Entity)

* [ ] Repository

* [x] API 설계

  * OCR 요청 및 응답 API 설계 및 구현

* [ ] DB 스키마

* [x] Security

  * `/api/v1/ocr/connect` Endpoint permitAll 설정 추가

---

## 🧪 테스트 방법

* [x] 로컬 서버 실행 후 정상 동작 확인
* [x] Postman을 이용하여 이미지 업로드 및 OCR API 호출 테스트
* [x] OCR 응답 데이터 정상 수신 확인
* [x] API Gateway 및 CLOVA OCR 연동 정상 동작 확인
* [ ] 예외 케이스 추가 테스트 (향후 보완 예정)

---

## ⚠️ 참고 사항

* 현재 단계에서는 OCR 응답 데이터를 그대로 반환하며, DB 저장 로직은 포함되어 있지 않음
* OCR 응답 파싱 및 Expense Entity 연동은 별도 PR에서 구현 예정
* templateId 없이도 서비스 배포된 기본 템플릿을 통해 OCR 동작 확인 완료
* 민감 정보(Secret Key, API Key)는 application-secret.yml로 분리하여 관리

---

## ✅ 체크리스트

* [x] main 브랜치 직접 push 하지 않음
* [x] feature 브랜치에서 작업
* [x] 불필요한 로그 제거 완료
* [x] API 동작 테스트 완료
* [x] 관련 이슈 연결 완료 (#27)
