### PR TITLE
[BE] refactor: GlobalExceptionHandler 클래스명 중복 충돌 해결

### DIFF
--- a/src/main/java/com/tripmoa/community/mate/Exception/MateExceptionHandler.java
+++ b/src/main/java/com/tripmoa/community/mate/Exception/MateExceptionHandler.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class MateExceptionHandler {
 
     @ExceptionHandler(MateException.class)
     public ResponseEntity<ErrorResponse> handleMateException(MateException e) {


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #36 #37

---

## 🛠️ 작업 내용 (What)
- **클래스명 변경**: `com.tripmoa.community.mate.Exception.GlobalExceptionHandler` -> `MateExceptionHandler`
- **충돌 제거**: 동일한 이름을 가진 두 개의 `@RestControllerAdvice` 빈(Bean) 충돌 문제 해결

---

## 🧭 작업 목적 (Why)
- `global` 패키지에 새로 추가된 공통 `GlobalExceptionHandler`와 클래스명이 중복되어 애플리케이션 실행이 불가능한 버그를 해결하기 위함
- 각 예외 처리기의 범위를 명확히 하여 관리 편의성 향상

---

## 🧩 변경 범위
- [ ] Controller
- [ ] Service
- [ ] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [x] Exception Handler (클래스명 리네이밍)

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행 (BeanDefinitionOverrideException 발생 여부 확인)
- [x] 애플리케이션 컨텍스트 정상 로드 확인

---

## ⚠️ 참고 사항
- 이번 작업은 단순 **클래스명 변경**이며, 내부 로직은 수정하지 않았습니다.
- 이후 메이트 도메인의 예외 처리 로직을 `global` 핸들러로 통합할 때 해당 클래스는 삭제될 예정입니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료