### PR TITLE
[BE] refactor: Mate ErrorCode 복구 및 예외 코드 정리

### DIFF
--- a/src/main/java/com/tripmoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/tripmoa/global/exception/ErrorCode.java
@@ -67,15 +67,6 @@ public enum ErrorCode {
     DEPOSIT_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "DEPOSIT_404_001", "depositLogId에 해당하는 입금 로그가 없습니다."),
 
 
-    // ====== Settlement 정책 (409 충돌) ======
-
-    // POOL 모드인데 split 정책을 바꾸려는 경우
-    SPLIT_POLICY_NOT_ALLOWED_IN_POOL(HttpStatus.CONFLICT, "SETTLEMENT_409_001", "POOL 모드에서는 분배 나머지 정책을 변경할 수 없습니다."),
-
-    // INDEPENDENT 모드인데 pool 정책을 바꾸려는 경우
-    POOL_POLICY_NOT_ALLOWED_IN_INDEPENDENT( HttpStatus.CONFLICT, "SETTLEMENT_409_002", "INDEPENDENT 모드에서는 공금 정산 정책을 변경할 수 없습니다."),
-
-
     // ====== OCR / 파일 업로드 ======
 
     // 파일이 비어있거나 형식이 잘못된 경우
@@ -87,6 +78,35 @@ public enum ErrorCode {
     // 네이버 OCR API 호출 실패 / 내부 처리 오류
     OCR_PROCESS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OCR_500_001", "OCR 처리 중 오류가 발생했습니다."),
 
+
+    // ====== Mate 도메인 ======
+
+    // 일정 관련 (1000번대)
+    INVALID_SCHEDULE(HttpStatus.BAD_REQUEST, "MATE_400_001", "유효하지 않은 여행 일정입니다"),
+    START_DATE_BEFORE_NOW(HttpStatus.BAD_REQUEST, "MATE_400_002", "시작일은 현재 이후여야 합니다"),
+    END_DATE_BEFORE_START(HttpStatus.BAD_REQUEST, "MATE_400_003", "종료일은 시작일 이후여야 합니다"),
+
+    // 참가자 관련 (2000번대)
+    INVALID_PARTICIPANT_INFO(HttpStatus.BAD_REQUEST, "MATE_400_004", "유효하지 않은 참가자 정보입니다"),
+    CURRENT_PARTICIPANT_TOO_LOW(HttpStatus.BAD_REQUEST, "MATE_400_005", "현재 인원은 1명 이상이어야 합니다"),
+    MAX_PARTICIPANT_TOO_LOW(HttpStatus.BAD_REQUEST, "MATE_400_006", "최대 인원은 2명 이상이어야 합니다"),
+    CURRENT_EXCEEDS_MAX(HttpStatus.BAD_REQUEST, "MATE_400_007", "현재 인원이 최대 인원을 초과할 수 없습니다"),
+    ALREADY_FULLY_BOOKED(HttpStatus.BAD_REQUEST, "MATE_400_008", "이미 모집 완료 상태입니다"),
+    PARTICIPANT_FULL(HttpStatus.BAD_REQUEST, "MATE_400_009", "모집 인원이 마감되었습니다"),
+
+    // 예산 관련 (3000번대)
+    INVALID_BUDGET(HttpStatus.BAD_REQUEST, "MATE_400_010", "예산은 0 이상이어야 합니다"),
+
+    // 게시글 관련 (4000번대)
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "MATE_404_001", "게시글을 찾을 수 없습니다"),
+    UNAUTHORIZED_POST_ACCESS(HttpStatus.FORBIDDEN, "MATE_403_001", "게시글 접근 권한이 없습니다"),
+
+    // 신청서 관련 (5000번대)
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "MATE_404_002", "신청서를 찾을 수 없습니다"),
+    ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "MATE_400_011", "이미 신청한 게시글입니다"),
+    CANNOT_APPLY_OWN_POST(HttpStatus.BAD_REQUEST, "MATE_400_012", "본인 게시글에는 신청할 수 없습니다"),
+    ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "MATE_400_013", "이미 처리된 신청서입니다"),
+    UNAUTHORIZED_APPLICATION_ACCESS(HttpStatus.FORBIDDEN, "MATE_403_002", "신청서 접근 권한이 없습니다"),
 
     // ====== 서버 내부 오류 ======
 


### PR DESCRIPTION
#45

## 🔗 관련 이슈
- Closes #44 #45 

---

## 🛠️ 작업 내용 (What)
- mate 도메인 ErrorCode(enum) 누락된 항목 복구
- 기존 mate 관련 로직에서 참조하던 에러 코드 정상 연결
- ErrorCode 전체 구조 내 mate 영역 정리

---

## 🧭 작업 목적 (Why)
- ErrorCode 삭제로 인해 발생한 컴파일 오류 및 예외 처리 문제 해결
- mate 도메인 예외 처리 정상화
- 도메인별 ErrorCode 관리 일관성 유지

---

## 🧩 변경 범위
- [ ] Controller
- [x] Service
- [ ] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

---

## ⚠️ 참고 사항
- ErrorCode는 여러 도메인에서 공통으로 사용되므로 삭제/수정 시 영향 범위 확인 필요
- 향후 도메인별 ErrorCode 분리 또는 관리 정책 정리 필요

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [ ] API 명세 변경 시 공유 완료