### PR TITLE
[BE] feature: 메이트 1:1 실시간 채팅 인프라 구축 및 Redis 기반 읽음 처리 구현

### DIFF
--- a/src/main/java/com/tripmoa/community/chat/config/StompHandler.java
+++ b/src/main/java/com/tripmoa/community/chat/config/StompHandler.java
@@ -1,0 +1,68 @@
+package com.tripmoa.community.chat.config;
+
+import com.tripmoa.security.jwt.JwtTokenProvider;
+import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.princpal.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+ // STOMP 연결 시 JWT 토큰 검증 인터셉터
+ // 클라이언트에서 WebSocket 연결 시 헤더에 JWT 토큰을 포함해야 함:
+ // stompClient.connect({ Authorization: "Bearer {token}" }, ...)
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompHandler implements ChannelInterceptor {
+
+     private final JwtTokenProvider jwtTokenProvider;
+     private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String authHeader = accessor.getFirstNativeHeader("Authorization");
+
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                throw new IllegalArgumentException("Authorization 헤더가 없습니다");
+            }
+
+            String token = authHeader.substring(7);
+
+            try {
+                // 프로젝트 기존 메서드 그대로 사용
+                if (!jwtTokenProvider.validateToken(token)) {
+                    throw new IllegalArgumentException("유효하지 않은 토큰입니다");
+                }
+
+                Long userId = jwtTokenProvider.getUserId(token);
+                CustomUserDetails userDetails = customUserDetailsService.loadUserById(userId);
+
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
+
+                accessor.setUser(auth);
+
+            } catch (Exception e) {
+                throw new IllegalArgumentException("유효하지 않은 토큰입니다");
+            }
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/tripmoa/community/chat/config/WebSocketConfig.java
@@ -1,0 +1,40 @@
+package com.tripmoa.community.chat.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompHandler stompHandler;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // 구독 경로: /sub/chat/room/{roomId}
+        config.enableSimpleBroker("/sub");
+        // 발행 경로: /pub/chat/message
+        config.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("http://localhost:*", "https://tripmoa.com")  // 배포 시 수정
+                .withSockJS();
+    }
+
+    /**
+     * STOMP 메시지 인터셉터 등록 (JWT 인증)
+     */
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/controller/ChatController.java
+++ b/src/main/java/com/tripmoa/community/chat/controller/ChatController.java
@@ -1,0 +1,96 @@
+package com.tripmoa.community.chat.controller;
+
+import com.tripmoa.community.chat.dto.ChatMessageResponse;
+import com.tripmoa.community.chat.dto.ChatRequest;
+import com.tripmoa.community.chat.dto.ChatRoomResponse;
+import com.tripmoa.community.chat.service.ChatService;
+import com.tripmoa.community.chat.service.UnreadMessageCheck;
+import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.user.entity.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+    private final UnreadMessageCheck unreadMessageCheck;
+
+    // 채팅방 생성
+    @PostMapping("/rooms")
+    public ResponseEntity<ChatRoomResponse> createRoom(
+            @Valid @RequestBody ChatRequest.CreateRoom request,
+            @AuthenticationPrincipal CustomUserDetails userDetails   // 로그인한 유저와 글 쓴 유저 일치하는지 확인
+    ) {
+        User user = userDetails.getUser();
+        ChatRoomResponse response = chatService.createChatRoom(request.getMatePostId(), user, request.getApplicantId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 채팅방 목록 조회
+    @GetMapping("/rooms")
+    public ResponseEntity<List<ChatRoomResponse>> getMyChatRooms(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User member = userDetails.getUser();
+        return ResponseEntity.ok(chatService.getMyChatRooms(member));
+    }
+
+    // 채팅방 상세 조회
+    @GetMapping("/rooms/{roomId}")
+    public ResponseEntity<ChatRoomResponse> getChatRoom(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User member = userDetails.getUser();
+        return ResponseEntity.ok(chatService.getChatRoom(roomId, member));
+    }
+
+    // 채팅방 메세지 조회
+    @GetMapping("/rooms/{roomId}/messages")
+    public ResponseEntity<List<ChatMessageResponse>> getMessages(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User member = userDetails.getUser();
+        return ResponseEntity.ok(chatService.getMessages(roomId, member));
+    }
+
+    // 메세지 전송
+    @PostMapping("/rooms/{roomId}/messages")
+    public ResponseEntity<ChatMessageResponse> sendMessage(
+            @PathVariable Long roomId,
+            @Valid @RequestBody ChatRequest.SendMessage request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User member = userDetails.getUser();
+        ChatMessageResponse response = chatService.sendMessage(roomId, request.getContent(), member);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/rooms/{roomId}/read")
+    public ResponseEntity<Void> markAsRead(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        unreadMessageCheck.clearUnread(roomId, userDetails.getUser().getId());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/rooms/{roomId}/leave")
+    public ResponseEntity<Void> leaveRoom(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        chatService.leaveRoom(roomId, userDetails.getUser());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/controller/StompController.java
+++ b/src/main/java/com/tripmoa/community/chat/controller/StompController.java
@@ -1,0 +1,47 @@
+package com.tripmoa.community.chat.controller;
+
+import com.tripmoa.community.chat.dto.ChatMessageResponse;
+import com.tripmoa.community.chat.dto.ChatRequest;
+import com.tripmoa.community.chat.service.ChatService;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+/**
+ * STOMP 메시지 핸들러
+ *
+ * 클라이언트 → 서버: /pub/chat/message  (메시지 전송)
+ * 서버 → 클라이언트: /sub/chat/room/{roomId}  (메시지 수신 구독)
+ */
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class StompController {
+
+    private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final UserRepository userRepository;
+
+    // 클라이언트가 /pub/chat/message 로 메시지를 보내면
+    // DB에 저장 후 해당 채팅방 구독자들에게 브로드캐스트
+    @MessageMapping("/chat/message")
+    public void sendMessage(ChatRequest.SendMessage request, Principal principal) {
+        // 인증된 사용자 조회
+        User sender = userRepository.findById(Long.parseLong(principal.getName()))
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+        // DB 저장
+        ChatMessageResponse response = chatService.sendMessage(
+                request.getChatRoomId(), request.getContent(), sender);
+
+        // 해당 채팅방 구독자에게 브로드캐스트
+        String destination = "/sub/chat/room/" + request.getChatRoomId();
+        messagingTemplate.convertAndSend(destination, response);
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/domain/ChatMessage.java
+++ b/src/main/java/com/tripmoa/community/chat/domain/ChatMessage.java
@@ -1,0 +1,44 @@
+package com.tripmoa.community.chat.domain;
+
+import com.tripmoa.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_message", indexes = {
+        @Index(name = "idx_chat_message_room_created", columnList = "chat_room_id, createdAt")
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    // 보낸 사람
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @Column(nullable = false, length = 2000)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private MessageType type = MessageType.CHAT;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/tripmoa/community/chat/domain/ChatRoom.java
+++ b/src/main/java/com/tripmoa/community/chat/domain/ChatRoom.java
@@ -1,0 +1,96 @@
+package com.tripmoa.community.chat.domain;
+
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "chat_room",
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"mate_post_id", "applicant_id"}  // 같은 게시글+신청자 조합은 1개만
+        ))
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 연결된 메이트 모집 게시글
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mate_post_id", nullable = false)
+    private MatePost matePost;
+
+    // 게시글 작성자 (방장)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    // 신청자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false)
+    private User applicant;
+
+    // 채팅 메시지 목록
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    @Builder.Default
+    private List<ChatMessage> messages = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastMessageAt;
+
+    @Column(nullable = false)
+    private boolean authorLeft = false;
+
+    @Column(nullable = false)
+    private boolean applicantLeft = false;
+
+    // === 비즈니스 메서드 ===
+
+    public void updateLastMessageAt(LocalDateTime time) {
+        this.lastMessageAt = time;
+    }
+
+    // 채팅방 회원 확인
+    public boolean isMember(User user) {
+        return author.getId().equals(user.getId())
+                || applicant.getId().equals(user.getId());
+    }
+
+    // 상대방 조회
+    public User getOtherMember(User me) {
+        return author.getId().equals(me.getId()) ? applicant : author;
+    }
+
+    //
+    public void markLeft(User user) {
+        if(user.getId().equals(author.getId())) {
+            this.authorLeft = true;
+        } else if(user.getId().equals(applicant.getId())) {
+            this.applicantLeft = true;
+        }
+    }
+
+    public boolean hasLeft(User user) {
+        if(user.getId().equals(author.getId())) return authorLeft;
+        if(user.getId().equals(applicant.getId())) return applicantLeft;
+        return false;
+    }
+
+    public boolean bothLeft() {
+        return authorLeft && applicantLeft;
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/domain/MessageType.java
+++ b/src/main/java/com/tripmoa/community/chat/domain/MessageType.java
@@ -1,0 +1,10 @@
+package com.tripmoa.community.chat.domain;
+
+public enum MessageType {
+    CHAT,
+    LEAVE,
+    SYSTEM;
+
+
+
+}

--- a/src/main/java/com/tripmoa/community/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/tripmoa/community/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,30 @@
+package com.tripmoa.community.chat.dto;
+
+import com.tripmoa.community.chat.domain.ChatMessage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageResponse {
+
+    private String id;
+    private String senderId;
+    private String senderName;
+    private String senderAvatar;
+    private String content;
+    private String timestamp;
+    private String type;
+
+    public static ChatMessageResponse from(ChatMessage message) {
+        return ChatMessageResponse.builder()
+                .id(String.valueOf(message.getId()))
+                .senderId(message.getSender().getEmail())
+                .senderName(message.getSender().getName())
+                .senderAvatar(message.getSender().getProfileImage())
+                .content(message.getContent())
+                .timestamp(message.getCreatedAt().toString())
+                .type(message.getType().name())
+                .build();
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/dto/ChatRequest.java
+++ b/src/main/java/com/tripmoa/community/chat/dto/ChatRequest.java
@@ -1,0 +1,32 @@
+package com.tripmoa.community.chat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChatRequest {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateRoom {
+
+        @NotNull(message = "게시글 ID는 필수입니다")
+        private Long matePostId;
+
+        private Long applicantId;
+    }
+
+     // STOMP 메시지 전송 요청
+     // 프론트에서 /pub/chat/message 로 보낼 때 사용
+    @Getter
+    @NoArgsConstructor
+    public static class SendMessage {
+
+        @NotNull(message = "채팅방 ID는 필수입니다")
+        private Long chatRoomId;
+
+        @NotBlank(message = "메시지 내용은 필수입니다")
+        private String content;
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/tripmoa/community/chat/dto/ChatRoomResponse.java
@@ -1,0 +1,73 @@
+package com.tripmoa.community.chat.dto;
+
+import com.tripmoa.community.chat.domain.ChatRoom;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatRoomResponse {
+
+    private String id;                  // chatRoom ID
+    private String postId;              // 게시글 ID
+    private String postAuthorId;        // 게시글 작성자 이메일
+    private String applicantId;         // 신청자 이메일
+    private String destination;         // 여행지
+    private String startDate;           // 여행 시작일
+    private String endDate;             // 여행 종료일
+    private MemberInfo postAuthor;      // 작성자 정보
+    private MemberInfo applicant;       // 신청자 정보
+    private List<ChatMessageResponse> messages;
+    private String lastMessageAt;
+    private String createdAt;
+    private int unreadCount;
+
+    @Getter
+    @Builder
+    public static class MemberInfo {
+        private Long id;
+        private String name;
+        private String email;
+        private String profileImage;
+        private String avatarEmoji;
+        private String avatarColor;
+    }
+
+    public static ChatRoomResponse from(ChatRoom room, int unreadCount) {
+        return ChatRoomResponse.builder()
+                .id(String.valueOf(room.getId()))
+                .postId(String.valueOf(room.getMatePost().getId()))
+                .postAuthorId(room.getAuthor().getEmail())
+                .applicantId(room.getApplicant().getEmail())
+                .destination(room.getMatePost().getDestination())
+                .startDate(room.getMatePost().getStartDate().toString())
+                .endDate(room.getMatePost().getEndDate().toString())
+                .postAuthor(MemberInfo.builder()
+                        .id(room.getAuthor().getId())
+                        .name(room.getAuthor().getName())
+                        .email(room.getAuthor().getEmail())
+                        .profileImage(room.getAuthor().getProfileImage())
+                        .avatarEmoji(room.getAuthor().getAvatarEmoji())
+                        .avatarColor(room.getAuthor().getAvatarColor())
+                        .build())
+                .applicant(MemberInfo.builder()
+                        .id(room.getApplicant().getId())
+                        .name(room.getApplicant().getName())
+                        .email(room.getApplicant().getEmail())
+                        .profileImage(room.getApplicant().getProfileImage())
+                        .avatarEmoji(room.getAuthor().getAvatarEmoji())
+                        .avatarColor(room.getAuthor().getAvatarColor())
+                        .build())
+                .messages(room.getMessages().stream()
+                        .map(ChatMessageResponse::from)
+                        .toList())
+                .lastMessageAt(room.getLastMessageAt() != null
+                        ? room.getLastMessageAt().toString()
+                        : room.getCreatedAt().toString())
+                .createdAt(room.getCreatedAt().toString())
+                .unreadCount(unreadCount)
+                .build();
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/tripmoa/community/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,26 @@
+package com.tripmoa.community.chat.repository;
+
+import com.tripmoa.community.chat.domain.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    // 특정 채팅방의 메시지 조회 (최신순, 페이징)
+    @Query("SELECT m FROM ChatMessage m " +
+            "JOIN FETCH m.sender " +
+            "WHERE m.chatRoom.id = :roomId " +
+            "ORDER BY m.createdAt ASC")
+    List<ChatMessage> findAllByChatRoomId(@Param("roomId") Long roomId);
+
+     // 특정 채팅방의 최근 메시지 N건 조회 (역순 페이징)
+    @Query("SELECT m FROM ChatMessage m " +
+            "JOIN FETCH m.sender " +
+            "WHERE m.chatRoom.id = :roomId " +
+            "ORDER BY m.createdAt DESC")
+    List<ChatMessage> findRecentMessages(@Param("roomId") Long roomId, Pageable pageable);
+}

--- a/src/main/java/com/tripmoa/community/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/tripmoa/community/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,30 @@
+package com.tripmoa.community.chat.repository;
+
+import com.tripmoa.community.chat.domain.ChatRoom;
+import com.tripmoa.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    // 참여한 채팅방 조회
+    @Query("SELECT DISTINCT r FROM ChatRoom r " +
+            "JOIN FETCH r.author " +
+            "JOIN FETCH r.applicant " +
+            "JOIN FETCH r.matePost " +
+            "LEFT JOIN FETCH r.messages m " +
+            "WHERE (r.author = :member AND r.authorLeft = false) " +
+            "OR (r.applicant = :member AND r.applicantLeft = false) " +
+            "ORDER BY r.lastMessageAt DESC")
+    List<ChatRoom> findAllByMemberNotLeft(@Param("member") User member);
+
+    // 게시글 + 신청자 조합 검색
+    Optional<ChatRoom> findByMatePostIdAndApplicantId(Long matePostId, Long applicantId);
+
+    // 게시글 아이디로 채팅방 찾기
+    List<ChatRoom> findAllByMatePostId(Long matePostId);
+}

--- a/src/main/java/com/tripmoa/community/chat/service/ChatService.java
+++ b/src/main/java/com/tripmoa/community/chat/service/ChatService.java
@@ -1,0 +1,163 @@
+package com.tripmoa.community.chat.service;
+
+import com.tripmoa.community.chat.domain.ChatMessage;
+import com.tripmoa.community.chat.domain.ChatRoom;
+import com.tripmoa.community.chat.domain.MessageType;
+import com.tripmoa.community.chat.dto.ChatMessageResponse;
+import com.tripmoa.community.chat.dto.ChatRoomResponse;
+import com.tripmoa.community.chat.repository.ChatMessageRepository;
+import com.tripmoa.community.chat.repository.ChatRoomRepository;
+import com.tripmoa.community.mate.domain.MatePost;
+import com.tripmoa.community.mate.repository.MateRepository;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final MateRepository mateRepository;
+    private final UserRepository userRepository;
+    private final UnreadMessageCheck unreadMessageCheck;
+    private final SimpMessagingTemplate messagingTemplate;
+
+     // 채팅방 생성 (메이트 신청 시 호출)
+     // 이미 존재하면 기존 채팅방 반환
+     // 자기 자신의 게시글에는 채팅방 생성 불가
+    @Transactional
+    public ChatRoomResponse createChatRoom(Long matePostId, User requestUser, Long applicantId) {
+        MatePost post = mateRepository.findById(matePostId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다: " + matePostId));
+
+        User author = post.getUser();
+        User applicant = userRepository.findById(applicantId)
+                .orElseThrow(() -> new IllegalArgumentException("신청자를 찾을 수 없습니다"));
+
+        // 자기 자신에게 채팅 신청 방지
+        if (author.getId().equals(applicant.getId())) {
+            throw new IllegalArgumentException("자기 자신에게 채팅을 신청 할 수 없습니다");
+        }
+
+        // 이미 존재하는 채팅방이면 그대로 반환
+        return chatRoomRepository.findByMatePostIdAndApplicantId(matePostId, applicant.getId())
+                .map(room -> ChatRoomResponse.from(room, 0))
+                .orElseGet(() -> {
+                    ChatRoom room = ChatRoom.builder()
+                            .matePost(post)
+                            .author(author)
+                            .applicant(applicant)
+                            .lastMessageAt(LocalDateTime.now())
+                            .build();
+
+                    ChatRoom saved = chatRoomRepository.save(room);
+
+                    return ChatRoomResponse.from(saved, 0);
+                });
+    }
+
+    // 내 채팅방 목록 조회
+    public List<ChatRoomResponse> getMyChatRooms(User member) {
+        return chatRoomRepository.findAllByMemberNotLeft(member).stream()
+                .map(room -> ChatRoomResponse.from(
+                        room,
+                        unreadMessageCheck.getUnreadCount(room.getId(), member.getId())
+                ))
+                .toList();
+    }
+
+    // 특정 채팅방 조회 (권한 검증 포함)
+    public ChatRoomResponse getChatRoom(Long roomId, User member) {
+        ChatRoom room = findRoomOrThrow(roomId);
+        validateMembership(room, member);
+        unreadMessageCheck.clearUnread(roomId, member.getId());
+        return ChatRoomResponse.from(room, 0);
+    }
+
+    // 메시지 전송 (REST API용 - STOMP 사용 시에도 DB 저장용으로 호출)
+    @Transactional
+    public ChatMessageResponse sendMessage(Long chatRoomId, String content, User sender) {
+        ChatRoom room = findRoomOrThrow(chatRoomId);
+        validateMembership(room, sender);
+
+        if (room.hasLeft(sender)) {
+            throw new IllegalStateException("이미 나간 채팅방에는 메시지를 보낼 수 없습니다.");
+        }
+
+        ChatMessage message = ChatMessage.builder()
+                .chatRoom(room)
+                .sender(sender)
+                .content(content)
+                .type(MessageType.CHAT)
+                .build();
+
+        ChatMessage saved = chatMessageRepository.save(message);
+        room.updateLastMessageAt(saved.getCreatedAt());
+
+        User receiver = room.getOtherMember(sender);
+        unreadMessageCheck.incrementUnread(chatRoomId, receiver.getId());
+
+        return ChatMessageResponse.from(saved);
+    }
+
+    // 특정 채팅방의 메시지 목록 조회
+    public List<ChatMessageResponse> getMessages(Long chatRoomId, User member) {
+        ChatRoom room = findRoomOrThrow(chatRoomId);
+        validateMembership(room, member);
+
+        return chatMessageRepository.findAllByChatRoomId(chatRoomId).stream()
+                .map(ChatMessageResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void leaveRoom(Long roomId, User member) {
+         ChatRoom room = findRoomOrThrow(roomId);
+         validateMembership(room, member);
+
+         room.markLeft(member);
+
+        ChatMessage systemMessage = ChatMessage.builder()
+                .chatRoom(room)
+                .sender(member)
+                .content(member.getName() + "님이 채팅방을 나갔습니다.")
+                .type(MessageType.LEAVE)
+                .build();
+        chatMessageRepository.save(systemMessage);
+        room.updateLastMessageAt(systemMessage.getCreatedAt());
+
+        if (room.bothLeft()) {
+            chatRoomRepository.delete(room);
+        }
+
+        unreadMessageCheck.clearUnread(roomId, member.getId());
+
+        // 상대방에게 나가기 알림
+        ChatMessageResponse response = ChatMessageResponse.from(systemMessage);
+        messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, response);
+    }
+
+    // === Private 헬퍼 메서드 ===
+
+    private ChatRoom findRoomOrThrow(Long roomId) {
+        return chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다: " + roomId));
+    }
+
+    private void validateMembership(ChatRoom room, User member) {
+        if (!room.isMember(member)) {
+            throw new SecurityException("이 채팅방에 접근할 권한이 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/service/UnreadMessageCheck.java
+++ b/src/main/java/com/tripmoa/community/chat/service/UnreadMessageCheck.java
@@ -1,0 +1,29 @@
+package com.tripmoa.community.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UnreadMessageCheck {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private String unreadKey(Long roomId, Long userId) {
+        return "chat:unread:" + roomId + ":" + userId;
+    }
+
+    public void incrementUnread(Long roomId, Long receivedId) {
+        redisTemplate.opsForValue().increment(unreadKey(roomId, receivedId));
+    }
+
+    public void clearUnread(Long roomId, Long userId) {
+        redisTemplate.delete(unreadKey(roomId, userId));
+    }
+
+    public int getUnreadCount(Long roomId, Long userId) {
+        String val = redisTemplate.opsForValue().get(unreadKey(roomId, userId));
+        return val != null ? Integer.parseInt(val) : 0;
+    }
+}

--- a/src/main/java/com/tripmoa/community/chat/utils/ChatDestinationUtils.java
+++ b/src/main/java/com/tripmoa/community/chat/utils/ChatDestinationUtils.java
@@ -1,0 +1,7 @@
+package com.tripmoa.community.chat.utils;
+
+public class ChatDestinationUtils {
+    public static String roomDestination(Long roomId) {
+        return "/sub/chat/room/" + roomId;
+    }
+}

--- a/src/main/java/com/tripmoa/community/mate/dto/ApplicationResponse.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/ApplicationResponse.java
@@ -1,5 +1,6 @@
 package com.tripmoa.community.mate.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tripmoa.community.mate.domain.MateApplication;
 import com.tripmoa.community.mate.domain.MatePost;
 import com.tripmoa.community.mate.enums.ApplyStatus;
@@ -10,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
+
 @Builder
 @Getter
 @Setter
@@ -19,10 +22,21 @@ public class ApplicationResponse {
     private Long applicantId;
     private String applicantName;
     private String applicantEmail;
+
+    private String postAuthorName;
+    private String postAuthorEmail;
+    private String postAuthorAvatar;
+
     private ApplyStatus status;
     private String content;
     private Long matePostId;
     private String postDestination;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
 
     private String avatar;
     private int age;
@@ -44,8 +58,13 @@ public class ApplicationResponse {
                 .applicantId(applicant.getId())
                 .applicantName(applicant.getName())
                 .applicantEmail(applicant.getEmail())
+                .postAuthorName(post.getUser().getName())
+                .postAuthorEmail(post.getUser().getEmail())
+                .postAuthorAvatar(post.getUser().getAvatarEmoji())
                 .matePostId(post.getId())
                 .postDestination(post.getDestination())
+                .startDate(post.getStartDate())
+                .endDate(post.getEndDate())
                 .status(application.getStatus())
                 .content(application.getContent())
                 .avatar(applicant.getAvatarEmoji())

--- a/src/main/java/com/tripmoa/global/config/SecurityConfig.java
+++ b/src/main/java/com/tripmoa/global/config/SecurityConfig.java
@@ -88,6 +88,9 @@ public class SecurityConfig {
                         // 업로드된 이미지 파일 : 인증 없이 접근 가능
                         .requestMatchers("/uploads/**").permitAll()
 
+                        // 웹소켓
+                        .requestMatchers("/ws/**").permitAll()
+
                         // 그 외 모든 요청 : 인증(로그인) 필요
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #50

---

## 🛠️ 작업 내용 (What)

- 채팅방 CRUD REST API 구현 (생성, 목록 조회, 상세 조회, 메시지 전송)
- STOMP WebSocket 실시간 메시지 핸들러 구현 
  (StompController — /pub/chat/message -> /sub/chat/room/{roomId})
- StompController에서 principal.getName()을 userId(Long)로 조회하도록 수정
- SecurityConfig에 `/ws/**` permitAll 추가 (SockJS info 요청 401 해결)
- Redis 기반 안 읽은 메시지 관리 (ChatRedisService — incrementUnread, clearUnread, getUnreadCount)
- 메시지 전송 시 상대방 unread +1, 채팅방 조회 시 unread 초기화
- ChatRoomResponse에 unreadCount 필드 추가 및 from(room, unreadCount) 오버로드
- ChatMessageResponse에 type 필드 추가 (CHAT, LEAVE, SYSTEM 구분)
- 채팅방 나가기 API 구현 (참여자별 독립 나가기 — authorLeft/applicantLeft)
- 나가기 시 시스템 메시지 DB 저장 + STOMP 브로드캐스트
- 양쪽 모두 나가면 채팅방 자동 삭제
- 나간 사용자 메시지 전송 차단
- ChatRoomRepository fetch join 쿼리로 N+1 문제 방지 (findAllByMemberNotLeft)
- MessageType enum에 LEAVE 추가
- ChatRoom Entity에 markLeft, hasLeft, bothLeft, getOtherMember 메서드 추가

---

## 🧭 작업 목적 (Why)

- 메이트 매칭 후 글 작성자와 신청자 간 1:1 실시간 채팅 인프라 제공
REST API와 STOMP WebSocket을 결합
Redis로 읽음 상태를 경량 관리
참여자별 독립적 나가기 처리로 한쪽이 나가도 상대방 채팅 유지

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [x] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인
- 테스트 시나리오:
  1. `POST /api/chat/rooms` — 채팅방 생성 (중복 시 기존 방 반환, 자기 자신 신청 시 400)
  2. `GET /api/chat/rooms` — 내 채팅방 목록 조회 (unreadCount 포함, 나간 방 제외)
  3. `GET /api/chat/rooms/{roomId}` — 채팅방 상세 조회 (열면 unread 초기화)
  4. `POST /api/chat/rooms/{roomId}/messages` — REST 메시지 전송 (상대방 unread +1)
  5. `PUT /api/chat/rooms/{roomId}/read` — 읽음 처리 (Redis unread 삭제, 204 응답)
  6. `DELETE /api/chat/rooms/{roomId}/leave` — 나가기 (시스템 메시지 저장 + STOMP 브로드캐스트, 204 응답)
  7. STOMP `/pub/chat/message` — 실시간 메시지 전송 -> `/sub/chat/room/{roomId}`로 브로드캐스트
  8. 나간 사용자가 메시지 전송 시도 -> IllegalStateException
  9. 양쪽 모두 나가기 → 채팅방 DB에서 삭제 확인

---

## ⚠️ 참고 사항

- 프론트엔드 PR과 함께 머지 필요 (ChatSlideModal, useChat, useStompClient)
- Redis 의존성 필요 — `spring-boot-starter-data-redis` 및 로컬 Redis 서버 실행 필요
- ChatRoom Entity에 `author_left`, `applicant_left` 컬럼 추가됨 (boolean, default false) — **DDL 자동 생성 또는 마이그레이션 필요**
- MessageType enum에 `LEAVE` 추가됨 — 기존 DB 데이터와 충돌 없음 (신규 enum 값)
- `ChatRoomResponse.from(room)` 단일 파라미터 호출부 → `from(room, 0)`으로 전부 변경 필요
- `findAllByMember` 쿼리를 `findAllByMemberNotLeft`로 교체 — fetch join으로 author, applicant, matePost, messages 한 번에 로딩
- StompHandler에서 JWT 파싱 후 세팅하는 user-name이 userId(숫자)이므로, StompController에서 `findById(Long.parseLong(principal.getName()))` 사용

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료