### PR TITLE
[BE] feature: Notices & Voucher ERD 설계 및 API 구현

### DIFF
--- a/src/main/java/com/tripmoa/blog/controller/BlogCommentController.java
+++ b/src/main/java/com/tripmoa/blog/controller/BlogCommentController.java
@@ -3,7 +3,7 @@ package com.tripmoa.blog.controller;
 import com.tripmoa.blog.dto.comment.CommentCreateRequest;
 import com.tripmoa.blog.dto.comment.CommentResponse;
 import com.tripmoa.blog.service.BlogCommentService;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/tripmoa/blog/controller/BlogController.java
+++ b/src/main/java/com/tripmoa/blog/controller/BlogController.java
@@ -5,7 +5,7 @@ import com.tripmoa.blog.dto.post.BlogResponse;
 import com.tripmoa.blog.dto.post.BlogUpdateRequest;
 import com.tripmoa.blog.service.BlogService;
 import com.tripmoa.blog.service.BlogLikeService;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import com.tripmoa.blog.service.SavedItineraryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/tripmoa/blog/controller/DraftController.java
+++ b/src/main/java/com/tripmoa/blog/controller/DraftController.java
@@ -4,7 +4,7 @@ import com.tripmoa.blog.dto.draft.DraftCreateRequest;
 import com.tripmoa.blog.dto.draft.DraftResponse;
 import com.tripmoa.blog.dto.draft.DraftUpdateRequest;
 import com.tripmoa.blog.service.DraftService;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/tripmoa/community/chat/config/StompHandler.java
+++ b/src/main/java/com/tripmoa/community/chat/config/StompHandler.java
@@ -1,8 +1,8 @@
 package com.tripmoa.community.chat.config;
 
 import com.tripmoa.security.jwt.JwtTokenProvider;
-import com.tripmoa.security.princpal.CustomUserDetails;
-import com.tripmoa.security.princpal.CustomUserDetailsService;
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;

--- a/src/main/java/com/tripmoa/community/chat/controller/ChatController.java
+++ b/src/main/java/com/tripmoa/community/chat/controller/ChatController.java
@@ -5,7 +5,7 @@ import com.tripmoa.community.chat.dto.ChatRequest;
 import com.tripmoa.community.chat.dto.ChatRoomResponse;
 import com.tripmoa.community.chat.service.ChatService;
 import com.tripmoa.community.chat.service.UnreadMessageCheck;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import com.tripmoa.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/tripmoa/community/mate/controller/MateController.java
+++ b/src/main/java/com/tripmoa/community/mate/controller/MateController.java
@@ -1,11 +1,10 @@
 package com.tripmoa.community.mate.controller;
 
-import com.tripmoa.community.mate.domain.MatePost;
 import com.tripmoa.community.mate.dto.*;
 import com.tripmoa.community.mate.service.MateApplicationService;
 import com.tripmoa.community.mate.service.MateLikeService;
 import com.tripmoa.community.mate.service.MateService;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import com.tripmoa.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +13,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 //import org.springframework.security.access.prepost.PreAuthorize;
 
-import java.security.Principal;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/tripmoa/expense/controller/DepositLogController.java
+++ b/src/main/java/com/tripmoa/expense/controller/DepositLogController.java
@@ -3,7 +3,7 @@ package com.tripmoa.expense.controller;
 import com.tripmoa.expense.dto.request.DepositLogCreateRequest;
 import com.tripmoa.expense.dto.response.DepositLogResponse;
 import com.tripmoa.expense.service.DepositLogService;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/tripmoa/expense/controller/ExpenseController.java
+++ b/src/main/java/com/tripmoa/expense/controller/ExpenseController.java
@@ -7,13 +7,15 @@ import com.tripmoa.expense.dto.response.ExpensePreviewResponse;
 import com.tripmoa.expense.dto.response.ExpenseResponse;
 import com.tripmoa.expense.service.ExpenseService;
 import com.tripmoa.expense.service.SettlementPreviewService;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -48,22 +50,24 @@ public class ExpenseController {
     @PostMapping
     public ResponseEntity<ExpenseResponse> create(
             @PathVariable Long tripId,
-            @Valid @RequestBody ExpenseCreateRequest request,
+            @Valid @RequestPart("request") ExpenseCreateRequest request,
+            @RequestPart(value = "receiptImage", required = false) MultipartFile receiptImage,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUser().getId();
-        return ResponseEntity.ok(expenseService.create(tripId, userId, request));
+        return ResponseEntity.ok(expenseService.create(tripId, userId, request, receiptImage));
     }
 
-    @PutMapping("/{expenseId}")
+    @PutMapping(value = "/{expenseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ExpenseResponse> update(
             @PathVariable Long tripId,
             @PathVariable Long expenseId,
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody ExpenseCreateRequest req
+            @Valid @RequestPart("request") ExpenseCreateRequest request,
+            @RequestPart(value = "receiptImage", required = false) MultipartFile receiptImage
     ) {
         Long userId = userDetails.getUser().getId();
-        return ResponseEntity.ok(expenseService.update(tripId, expenseId, userId, req));
+        return ResponseEntity.ok(expenseService.update(tripId, expenseId, userId, request, receiptImage));
     }
 
     @DeleteMapping("/{expenseId}")

--- a/src/main/java/com/tripmoa/expense/controller/OcrController.java
+++ b/src/main/java/com/tripmoa/expense/controller/OcrController.java
@@ -6,7 +6,7 @@ import com.tripmoa.expense.dto.response.OcrInitialResponse;
 import com.tripmoa.expense.service.OcrMapper;
 import com.tripmoa.expense.service.OcrService;
 import com.tripmoa.trip.service.TripPermissionService;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;

--- a/src/main/java/com/tripmoa/expense/controller/SettlementSettingController.java
+++ b/src/main/java/com/tripmoa/expense/controller/SettlementSettingController.java
@@ -5,7 +5,7 @@ import com.tripmoa.expense.dto.response.SettlementSettingResponse;
 import com.tripmoa.expense.dto.response.SettlementSummaryResponse;
 import com.tripmoa.expense.service.SettlementSettingService;
 import com.tripmoa.expense.service.SettlementSummaryService;
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;

--- a/src/main/java/com/tripmoa/expense/dto/request/ExpenseCreateRequest.java
+++ b/src/main/java/com/tripmoa/expense/dto/request/ExpenseCreateRequest.java
@@ -42,8 +42,6 @@ public record ExpenseCreateRequest(
         SplitMode splitMode,
 
         @Valid
-        List<ExpenseSplitCreateRequest> splits,
+        List<ExpenseSplitCreateRequest> splits
 
-        String receiptUrl,
-        String receiptFileName
 ) {}

--- a/src/main/java/com/tripmoa/expense/dto/response/ExpenseResponse.java
+++ b/src/main/java/com/tripmoa/expense/dto/response/ExpenseResponse.java
@@ -23,6 +23,9 @@ public record ExpenseResponse(
         Boolean isShared,
         SplitMode splitMode,
 
+        String receiptUrl,
+        String receiptFileName,
+
         LocalDateTime paidAt,
         LocalDateTime createdAt
 
@@ -39,6 +42,8 @@ public record ExpenseResponse(
                 e.getPayMethod(),
                 e.isShared(),
                 e.getSplitMode(),
+                e.getReceiptUrl(),
+                e.getReceiptFileName(),
                 e.getPaidAt(),
                 e.getCreatedAt()
         );

--- a/src/main/java/com/tripmoa/expense/enums/PayMethod.java
+++ b/src/main/java/com/tripmoa/expense/enums/PayMethod.java
@@ -1,8 +1,21 @@
 package com.tripmoa.expense.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 // 결제 방식
 public enum PayMethod {
-    CARD,       // 카드
-    CASH,       // 현금
-    QR          // QR, 간편결제
+    CARD, QR, CASH;
+
+    @JsonCreator
+    public static PayMethod fromText(String text) {
+        if (text == null) return CARD;
+
+        String t = text.toLowerCase();
+
+        if (t.contains("현금")) return CASH;
+        if (t.contains("qr") || t.contains("페이") || t.contains("pay")) return QR;
+        if (t.contains("카드") || t.contains("credit") || t.contains("check")) return CARD;
+
+        return CARD;
+    }
 }

--- a/src/main/java/com/tripmoa/expense/service/ExpenseService.java
+++ b/src/main/java/com/tripmoa/expense/service/ExpenseService.java
@@ -1,30 +1,34 @@
 package com.tripmoa.expense.service;
 
 import com.tripmoa.expense.dto.request.ExpenseCreateRequest;
-import com.tripmoa.expense.dto.request.ExpenseSplitCreateRequest;
 import com.tripmoa.expense.dto.request.ExpensePreviewManualSplitRequest;
 import com.tripmoa.expense.dto.request.ExpensePreviewRequest;
+import com.tripmoa.expense.dto.request.ExpenseSplitCreateRequest;
 import com.tripmoa.expense.dto.response.ExpenseDetailResponse;
 import com.tripmoa.expense.dto.response.ExpensePreviewResponse;
 import com.tripmoa.expense.dto.response.ExpenseResponse;
 import com.tripmoa.expense.entity.Expense;
 import com.tripmoa.expense.entity.ExpenseSplit;
 import com.tripmoa.expense.entity.SettlementSetting;
-import com.tripmoa.trip.entity.Trip;
-import com.tripmoa.trip.entity.TripMember;
 import com.tripmoa.expense.enums.PaymentMode;
 import com.tripmoa.expense.enums.SplitMode;
 import com.tripmoa.expense.repository.ExpenseRepository;
-import com.tripmoa.trip.repository.TripMemberRepository;
-import com.tripmoa.trip.repository.TripRepository;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.global.file.FileDirectories;
+import com.tripmoa.global.file.FileStorageService;
+import com.tripmoa.global.file.StoredFileInfo;
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.entity.TripMember;
+import com.tripmoa.trip.repository.TripMemberRepository;
+import com.tripmoa.trip.repository.TripRepository;
 import com.tripmoa.trip.service.TripPermissionService;
 import com.tripmoa.user.entity.User;
 import com.tripmoa.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -42,6 +46,7 @@ public class ExpenseService {
     private final ExpenseRepository expenseRepository;
     private final TripPermissionService tripPermissionService;
     private final SettlementPreviewService settlementPreviewService;
+    private final FileStorageService fileStorageService;
 
     @Transactional(readOnly = true)
     public List<ExpenseDetailResponse> getExpenses(Long tripId, Long userId) {
@@ -64,14 +69,13 @@ public class ExpenseService {
         return ExpenseDetailResponse.from(expense);
     }
 
-    public ExpenseResponse create(Long tripId, Long userId, ExpenseCreateRequest req) {
+    public ExpenseResponse create(Long tripId, Long userId, ExpenseCreateRequest req, MultipartFile receiptImage) {
         tripPermissionService.assertOwnerOrMember(tripId, userId);
 
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRIP_NOT_FOUND));
 
         SettlementSetting setting = tripPermissionService.getSettingOr404(tripId);
-
         validateSharedByPaymentMode(setting, req.isShared());
 
         User user = userRepository.findById(userId)
@@ -79,8 +83,12 @@ public class ExpenseService {
 
         TripMember payer = getValidPayer(tripId, req.payerMemberId());
         LocalDateTime paidAt = parsePaidAt(req.paidAt());
-
         List<ExpenseSplitCreateRequest> finalSplits = resolveFinalSplits(tripId, userId, req, payer);
+
+        StoredFileInfo storedFile = null;
+        if (receiptImage != null && !receiptImage.isEmpty()) {
+            storedFile = fileStorageService.store(receiptImage, FileDirectories.EXPENSE);
+        }
 
         Expense expense = Expense.builder()
                 .trip(trip)
@@ -94,8 +102,8 @@ public class ExpenseService {
                 .shared(req.isShared())
                 .category(req.category())
                 .payMethod(req.payMethod())
-                .receiptUrl(req.receiptUrl())
-                .receiptFileName(req.receiptFileName())
+                .receiptUrl(storedFile == null ? null : storedFile.fileUrl())
+                .receiptFileName(storedFile == null ? null : storedFile.originalFileName())
                 .splitMode(req.splitMode())
                 .build();
 
@@ -107,7 +115,7 @@ public class ExpenseService {
         return ExpenseResponse.from(saved);
     }
 
-    public ExpenseResponse update(Long tripId, Long expenseId, Long userId, ExpenseCreateRequest req) {
+    public ExpenseResponse update(Long tripId, Long expenseId, Long userId, ExpenseCreateRequest req, MultipartFile receiptImage) {
         tripPermissionService.assertOwnerOrMember(tripId, userId);
 
         Expense expense = expenseRepository.findById(expenseId)
@@ -118,13 +126,24 @@ public class ExpenseService {
         }
 
         SettlementSetting setting = tripPermissionService.getSettingOr404(tripId);
-
         validateSharedByPaymentMode(setting, req.isShared());
 
         TripMember payer = getValidPayer(tripId, req.payerMemberId());
         LocalDateTime paidAt = parsePaidAt(req.paidAt());
-
         List<ExpenseSplitCreateRequest> finalSplits = resolveFinalSplits(tripId, userId, req, payer);
+
+        String receiptUrl = expense.getReceiptUrl();
+        String receiptFileName = expense.getReceiptFileName();
+
+        if (receiptImage != null && !receiptImage.isEmpty()) {
+            if (expense.getReceiptUrl() != null && !expense.getReceiptUrl().isBlank()) {
+                fileStorageService.deleteFile(expense.getReceiptUrl());
+            }
+
+            StoredFileInfo storedFile = fileStorageService.store(receiptImage, FileDirectories.EXPENSE);
+            receiptUrl = storedFile.fileUrl();
+            receiptFileName = storedFile.originalFileName();
+        }
 
         expense.updateExpense(
                 payer,
@@ -136,8 +155,8 @@ public class ExpenseService {
                 req.category(),
                 req.payMethod(),
                 req.isShared(),
-                req.receiptUrl(),
-                req.receiptFileName(),
+                receiptUrl,
+                receiptFileName,
                 req.splitMode()
         );
 
@@ -159,6 +178,10 @@ public class ExpenseService {
 
         if (!expense.getTrip().getId().equals(tripId)) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST, "해당 trip의 영수증이 아닙니다.");
+        }
+
+        if (expense.getReceiptUrl() != null && !expense.getReceiptUrl().isBlank()) {
+            fileStorageService.deleteFile(expense.getReceiptUrl());
         }
 
         expenseRepository.delete(expense);

--- a/src/main/java/com/tripmoa/expense/service/OcrMapper.java
+++ b/src/main/java/com/tripmoa/expense/service/OcrMapper.java
@@ -98,21 +98,10 @@ public class OcrMapper {
                 base.storeName(),
                 base.menuName(),                       // menuName → itemMemo
                 ExpenseCategory.ETC,                   // 고정
-                mapPayMethod(base.paymentMethod()),    // 간단 매핑
+                PayMethod.fromText(base.paymentMethod()),
                 base.dateTime(),                       // dateTime → paidAt
                 base.totalAmount()
         );
     }
 
-    // PayMethod 간단 매핑
-    private PayMethod mapPayMethod(String paymentMethodText) {
-        if (paymentMethodText == null) return PayMethod.CARD;
-
-        String t = paymentMethodText.toLowerCase();
-        if (t.contains("현금")) return PayMethod.CASH;
-        if (t.contains("qr") || t.contains("페이") || t.contains("pay")) return PayMethod.QR;
-        if (t.contains("카드") || t.contains("credit") || t.contains("check")) return PayMethod.CARD;
-
-        return PayMethod.CARD;
-    }
 }

--- a/src/main/java/com/tripmoa/global/config/CorsConfig.java
+++ b/src/main/java/com/tripmoa/global/config/CorsConfig.java
@@ -1,10 +1,12 @@
 package com.tripmoa.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.*;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -21,34 +23,35 @@ import java.util.List;
 @Configuration
 public class CorsConfig {
 
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
     /**
      *  CORS 설정
      * - 프론트엔드(React, Next.js 등)에서 API 서버에 접근할 수 있도록 허용하는 설정입니다.
      * - React 개발 서버: http://localhost:3000 (또는 Vite 5173)
-     * - 배포 도메인 생기면 allowedOrigins에 추가
      */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
         // 개발용 : 접근을 허용할 프론트엔드 도메인 (주소들)
-        config.setAllowedOrigins(List.of(
-                "http://localhost:3000",
-                "http://localhost:5173"
-        ));
+        config.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
 
         // 허용할 HTTP 메서드
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+
         // 모든 헤더 허용
-        config.setAllowedHeaders(List.of("*"));
+        config.setAllowedHeaders(Arrays.asList("*"));
+
         // 프론트엔드에서 Authorization 헤더를 읽을 수 있도록 노출 (필요하면 토큰 헤더 노출)
-        config.setExposedHeaders(List.of("Authorization"));
+        config.setExposedHeaders(Arrays.asList("Authorization"));
+
         // 쿠키 및 인증 정보를 포함한 요청 허용
         config.setAllowCredentials(true);
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-
         // 모든 API 경로(/**)에 대해 위 설정을 적용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
     }

--- a/src/main/java/com/tripmoa/global/config/RedisConfig.java
+++ b/src/main/java/com/tripmoa/global/config/RedisConfig.java
@@ -12,7 +12,6 @@ import org.springframework.data.redis.serializer.RedisSerializer;
  * RedisConfig
  *
  * - Redis 연결 설정 클래스
- * - Lettuce 기반 RedisConnectionFactory 생성
  * - RedisTemplate Bean 등록 (Key: String, Value: JSON 직렬화)
  * - Redis Repository 사용 가능하도록 설정
  */
@@ -22,17 +21,13 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 public class RedisConfig {
 
     @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory("localhost", 6379);
-    }
-
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(redisConnectionFactory());
-        template.setKeySerializer(RedisSerializer.string()); // key
-        template.setValueSerializer(RedisSerializer.json()); // value
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(RedisSerializer.string());
+        template.setValueSerializer(RedisSerializer.json());
         return template;
     }
+
 }
 

--- a/src/main/java/com/tripmoa/global/config/SecurityConfig.java
+++ b/src/main/java/com/tripmoa/global/config/SecurityConfig.java
@@ -5,7 +5,7 @@ import com.tripmoa.security.jwt.JwtAuthenticationFilter;
 import com.tripmoa.security.jwt.JwtTokenProvider;
 import com.tripmoa.security.oauth.CustomOAuth2UserService;
 import com.tripmoa.security.oauth.OAuth2SuccessHandler;
-import com.tripmoa.security.princpal.CustomUserDetailsService;
+import com.tripmoa.security.principal.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -76,8 +76,9 @@ public class SecurityConfig {
                         // 소셜 로그인 관련 경로 : 인증 없이 접근 가능
                         .requestMatchers("/oauth2/**", "/login/oauth2/**", "/api/auth/**", "/api/test/**").permitAll()
 
-                        // 비로그인 사용자도 볼 수 있는 데이터 (Public API) -> GET 경로만 허용으로 수정하기
-                        .requestMatchers("/api/travelstory/**", "/api/mate/**").permitAll()
+                        // 비로그인 사용자도 볼 수 있는 데이터 (Public API) GET 경로만 허용
+                        .requestMatchers(HttpMethod.GET, "/api/travelstory/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/mate/**").permitAll()
 
                         // Swagger 경로 허용
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()

--- a/src/main/java/com/tripmoa/global/config/WebConfig.java
+++ b/src/main/java/com/tripmoa/global/config/WebConfig.java
@@ -1,16 +1,19 @@
 package com.tripmoa.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /* Web MVC 설정 (이미지)
- - 정적 리소스 경로 설정
- - CORS 설정 */
+ * - 정적 리소스 경로 설정
+ */
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
 
     /* 정적 리소스 핸들러 설정
      - /uploads/** 경로의 요청을 uploads/ 폴더로 매핑 */
@@ -18,17 +21,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         // /uploads/** 경로를 uploads/ 디렉토리로 매핑
         registry.addResourceHandler("/uploads/**")
-                .addResourceLocations("file:uploads/")
+                .addResourceLocations("file:" + uploadDir)
                 .setCachePeriod(3600); // 1시간 캐시
     }
 
-    /* CORS 설정 (이미지 요청 허용) */
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true);
-    }
 }

--- a/src/main/java/com/tripmoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/tripmoa/global/exception/ErrorCode.java
@@ -89,6 +89,13 @@ public enum ErrorCode {
 
 
     // ====== Mate 도메인 ======
+    NOTICE_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE_GROUP_404_001", "공지 그룹을 찾을 수 없습니다."),
+    NOTICE_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE_ITEM_404_001", "공지 메모를 찾을 수 없습니다."),
+    DUPLICATE_NOTICE_GROUP_NAME(HttpStatus.CONFLICT, "NOTICE_GROUP_409_001", "이미 사용 중인 공지 그룹명입니다."),
+    NOTICE_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE_TAG_404_001", "공지 태그를 찾을 수 없습니다."),
+
+
+    // ====== Mate 도메인 ======
 
     // 일정 관련 (1000번대)
     INVALID_SCHEDULE(HttpStatus.BAD_REQUEST, "MATE_400_001", "유효하지 않은 여행 일정입니다"),

--- a/src/main/java/com/tripmoa/global/file/FileDirectories.java
+++ b/src/main/java/com/tripmoa/global/file/FileDirectories.java
@@ -1,0 +1,20 @@
+package com.tripmoa.global.file;
+
+/**
+ * 파일 업로드 디렉토리 상수 정의
+ * - 각 도메인별 파일 저장 경로를 구분하기 위한 상수 클래스
+ * - 파일 저장 시 directory 파라미터로 사용됨
+ * - 사용 예시: fileStorageService.store(file, FileDirectories.EXPENSE);
+ * - 실제 저장 경로: uploads/{directory}/파일명
+ */
+public final class FileDirectories {
+
+    // 각 파일 저장 디렉토리
+    public static final String EXPENSE = "expense";
+    public static final String VOUCHER = "voucher";
+    public static final String BLOG = "blog";
+
+    // 인스턴스 생성 방지
+    private FileDirectories() {
+    }
+}

--- a/src/main/java/com/tripmoa/global/file/FileStorageService.java
+++ b/src/main/java/com/tripmoa/global/file/FileStorageService.java
@@ -1,0 +1,18 @@
+package com.tripmoa.global.file;
+
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 파일 저장/삭제 공통 인터페이스
+ * - 로컬 저장, S3 등 저장소 구현을 분리하기 위한 추상화 계층
+ * - 실제 저장 방식은 구현체에서 처리
+ * - 확장: LocalFileStorageService (현재) -> S3FileStorageService (추후)
+ */
+public interface FileStorageService {
+
+    // 파일을 지정한 디렉토리에 저장
+    StoredFileInfo store(MultipartFile file, String directory);
+
+    // 파일 삭제
+    void deleteFile(String fileUrl);
+}

--- a/src/main/java/com/tripmoa/global/file/LocalFileStorageService.java
+++ b/src/main/java/com/tripmoa/global/file/LocalFileStorageService.java
@@ -1,0 +1,127 @@
+package com.tripmoa.global.file;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+/**
+ * 로컬 파일 시스템 기반 파일 저장 구현체
+ * - application.properties의 file.upload-dir 경로를 기준으로 파일 저장
+ * - 디렉토리별로 파일을 구분하여 저장 (expense, voucher, blog)
+ * - 저장 구조: uploads/{directory}/{UUID 파일명}
+ */
+@Service
+public class LocalFileStorageService implements FileStorageService {
+
+    // 업로드 루트 경로 (ex: uploads/)
+    private final Path uploadRootPath;
+
+    // 업로드 루트 디렉토리 초기화 (서버 시작 시 uploads 폴더가 없으면 자동 생성)
+    public LocalFileStorageService(@Value("${file.upload-dir}") String uploadDir) {
+        this.uploadRootPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(this.uploadRootPath);
+        } catch (IOException e) {
+            throw new IllegalStateException("업로드 루트 폴더를 생성할 수 없습니다.", e);
+        }
+    }
+
+    // 파일 저장 처리
+    @Override
+    public StoredFileInfo store(MultipartFile file, String directory) {
+
+        // 파일 null 또는 비어있는 경우 예외
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드 파일이 없습니다.");
+        }
+
+        // 디렉토리 값 검증
+        if (directory == null || directory.isBlank()) {
+            throw new IllegalArgumentException("저장 디렉토리명이 비어 있습니다.");
+        }
+
+        // 원본 파일명 정리 (경로 제거 등)
+        String originalFileName = StringUtils.cleanPath(
+                file.getOriginalFilename() == null ? "" : file.getOriginalFilename()
+        );
+
+        // 확장자 추출
+        String extension = extractExtension(originalFileName);
+
+        // UUID 기반 파일명 생성 (중복 방지)
+        String savedFileName = UUID.randomUUID() + (extension.isBlank() ? "" : "." + extension);
+
+        try {
+            // 디렉토리 생성 (ex: uploads/expense)
+            Path dirPath = uploadRootPath.resolve(directory).normalize();
+            Files.createDirectories(dirPath);
+
+            // 실제 저장 경로
+            Path targetPath = dirPath.resolve(savedFileName).normalize();
+
+            // 파일 복사 (덮어쓰기 허용)
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            // 접근 URL 생성 (WebConfig에서 매핑됨)
+            String fileUrl = "/uploads/" + directory + "/" + savedFileName;
+
+            return new StoredFileInfo(
+                    fileUrl,
+                    savedFileName,
+                    originalFileName,
+                    file.getSize()
+            );
+        } catch (IOException e) {
+            throw new IllegalStateException("파일 저장에 실패했습니다.", e);
+        }
+    }
+    
+    // 파일 삭제
+    @Override
+    public void deleteFile(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            return;
+        }
+
+        try {
+            String normalizedUrl = fileUrl.replace("\\", "/");
+
+            // uploads 경로가 아닌 경우 무시
+            if (!normalizedUrl.startsWith("/uploads/")) {
+                return;
+            }
+
+            // 상대 경로 추출
+            String relativePath = normalizedUrl.substring("/uploads/".length());
+
+            Path targetPath = uploadRootPath.resolve(relativePath).normalize();
+
+            // 보안: 루트 경로 밖 접근 방지
+            if (!targetPath.startsWith(uploadRootPath)) {
+                return;
+            }
+
+            Files.deleteIfExists(targetPath);
+        } catch (IOException e) {
+            // 삭제 실패해도 서비스 흐름 유지
+            System.err.println("파일 삭제 실패: " + fileUrl);
+        }
+    }
+
+    // 파일 확장자 추출
+    private String extractExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf(".");
+        if (lastDotIndex == -1 || lastDotIndex == fileName.length() - 1) {
+            return "";
+        }
+        return fileName.substring(lastDotIndex + 1).toLowerCase();
+    }
+}

--- a/src/main/java/com/tripmoa/global/file/StoredFileInfo.java
+++ b/src/main/java/com/tripmoa/global/file/StoredFileInfo.java
@@ -1,0 +1,25 @@
+package com.tripmoa.global.file;
+
+/**
+ * 파일 저장 결과 DTO
+ * - 파일 저장 후 필요한 정보를 묶어서 반환
+ * - 각 도메인에서 필요한 값만 사용
+ * - expense → receipt_url, receipt_file_name
+ * - voucher → file_url, file_name, file_size
+ * - blog → image_url
+ */
+public record StoredFileInfo(
+
+        // 접근 가능한 파일 URL (/uploads/...)
+        String fileUrl,
+
+        // 서버에 저장된 파일명 (UUID 기반)
+        String fileName,
+
+        // 원본 파일명 (사용자 업로드 이름)
+        String originalFileName,
+
+        // 파일 크기 (bytes)
+        Long fileSize
+) {
+}

--- a/src/main/java/com/tripmoa/notice/controller/NoticeGroupController.java
+++ b/src/main/java/com/tripmoa/notice/controller/NoticeGroupController.java
@@ -1,0 +1,88 @@
+package com.tripmoa.notice.controller;
+
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.notice.dto.request.NoticeGroupCreateRequest;
+import com.tripmoa.notice.dto.request.NoticeGroupRenameRequest;
+import com.tripmoa.notice.dto.response.NoticeGroupResponse;
+import com.tripmoa.notice.service.NoticeGroupService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/trips/{tripId}/notice-groups")
+@RequiredArgsConstructor
+public class NoticeGroupController {
+
+    private final NoticeGroupService noticeGroupService;
+
+    /**
+     * 공지 그룹 전체 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<NoticeGroupResponse>> getNoticeGroups(
+            @PathVariable Long tripId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeGroupService.getNoticeGroups(tripId, userId));
+    }
+
+    /**
+     * 공지 그룹 단건 조회
+     */
+    @GetMapping("/{groupId}")
+    public ResponseEntity<NoticeGroupResponse> getNoticeGroup(
+            @PathVariable Long tripId,
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeGroupService.getNoticeGroup(tripId, groupId, userId));
+    }
+
+    /**
+     * 공지 그룹 생성
+     */
+    @PostMapping
+    public ResponseEntity<NoticeGroupResponse> createNoticeGroup(
+            @PathVariable Long tripId,
+            @Valid @RequestBody NoticeGroupCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeGroupService.createNoticeGroup(tripId, userId, request));
+    }
+
+    /**
+     * 공지 그룹 이름 수정
+     */
+    @PatchMapping("/{groupId}/name")
+    public ResponseEntity<NoticeGroupResponse> renameNoticeGroup(
+            @PathVariable Long tripId,
+            @PathVariable Long groupId,
+            @Valid @RequestBody NoticeGroupRenameRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeGroupService.renameNoticeGroup(tripId, groupId, userId, request));
+    }
+
+    /**
+     * 공지 그룹 삭제
+     */
+    @DeleteMapping("/{groupId}")
+    public ResponseEntity<Void> deleteNoticeGroup(
+            @PathVariable Long tripId,
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        noticeGroupService.deleteNoticeGroup(tripId, groupId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/tripmoa/notice/controller/NoticeItemController.java
+++ b/src/main/java/com/tripmoa/notice/controller/NoticeItemController.java
@@ -1,0 +1,146 @@
+package com.tripmoa.notice.controller;
+
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.notice.dto.request.NoticeItemCreateRequest;
+import com.tripmoa.notice.dto.request.NoticeItemUpdateRequest;
+import com.tripmoa.notice.dto.response.NoticeItemResponse;
+import com.tripmoa.notice.dto.response.NoticeTagResponse;
+import com.tripmoa.notice.service.NoticeItemService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/trips/{tripId}/notice-items")
+@RequiredArgsConstructor
+public class NoticeItemController {
+
+    private final NoticeItemService noticeItemService;
+
+    /**
+     * 공지 메모 전체 조회
+     * - groupId 기준으로 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<NoticeItemResponse>> getNoticeItems(
+            @PathVariable Long tripId,
+            @RequestParam Long groupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeItemService.getNoticeItems(tripId, groupId, userId));
+    }
+
+    /**
+     * 공지 메모 단건 조회
+     */
+    @GetMapping("/{noticeItemId}")
+    public ResponseEntity<NoticeItemResponse> getNoticeItem(
+            @PathVariable Long tripId,
+            @PathVariable Long noticeItemId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeItemService.getNoticeItem(tripId, noticeItemId, userId));
+    }
+
+    /**
+     * 공지 메모 생성
+     */
+    @PostMapping
+    public ResponseEntity<NoticeItemResponse> createNoticeItem(
+            @PathVariable Long tripId,
+            @Valid @RequestBody NoticeItemCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeItemService.createNoticeItem(tripId, userId, request));
+    }
+
+    /**
+     * 공지 메모 수정
+     */
+    @PatchMapping("/{noticeItemId}")
+    public ResponseEntity<NoticeItemResponse> updateNoticeItem(
+            @PathVariable Long tripId,
+            @PathVariable Long noticeItemId,
+            @Valid @RequestBody NoticeItemUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeItemService.updateNoticeItem(tripId, noticeItemId, userId, request));
+    }
+
+    /**
+     * 공지 메모 삭제
+     */
+    @DeleteMapping("/{noticeItemId}")
+    public ResponseEntity<Void> deleteNoticeItem(
+            @PathVariable Long tripId,
+            @PathVariable Long noticeItemId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        noticeItemService.deleteNoticeItem(tripId, noticeItemId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 핀 고정
+     * - 모든 멤버 가능
+     */
+    @PatchMapping("/{noticeItemId}/pin")
+    public ResponseEntity<NoticeItemResponse> pinNoticeItem(
+            @PathVariable Long tripId,
+            @PathVariable Long noticeItemId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeItemService.pinNoticeItem(tripId, noticeItemId, userId));
+    }
+
+    /**
+     * 핀 해제
+     * - 소유주만 가능
+     */
+    @PatchMapping("/{noticeItemId}/unpin")
+    public ResponseEntity<NoticeItemResponse> unpinNoticeItem(
+            @PathVariable Long tripId,
+            @PathVariable Long noticeItemId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeItemService.unpinNoticeItem(tripId, noticeItemId, userId));
+    }
+
+    /**
+     * 최근 사용 태그 조회
+     */
+    @GetMapping("/tags/recent")
+    public ResponseEntity<List<NoticeTagResponse>> getRecentNoticeTags(
+            @PathVariable Long tripId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(noticeItemService.getRecentNoticeTags(tripId, userId));
+    }
+
+    /**
+     * 태그 삭제
+     * - 소유주만 가능
+     */
+    @DeleteMapping("/tags/{tagId}")
+    public ResponseEntity<Void> deleteNoticeTag(
+            @PathVariable Long tripId,
+            @PathVariable Long tagId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        noticeItemService.deleteNoticeTag(tripId, tagId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/tripmoa/notice/dto/request/NoticeGroupCreateRequest.java
+++ b/src/main/java/com/tripmoa/notice/dto/request/NoticeGroupCreateRequest.java
@@ -1,0 +1,18 @@
+package com.tripmoa.notice.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NoticeGroupCreateRequest(
+
+        @NotBlank(message = "그룹명은 필수입니다.")
+        @Size(max = 60, message = "그룹명은 60자 이하여야 합니다.")
+        String name,
+
+        @Min(value = 0, message = "정렬 순서는 0 이상이어야 합니다.")
+        @Max(value = 9999, message = "정렬 순서는 9999 이하여야 합니다.")
+        Integer sortOrder
+) {
+}

--- a/src/main/java/com/tripmoa/notice/dto/request/NoticeGroupRenameRequest.java
+++ b/src/main/java/com/tripmoa/notice/dto/request/NoticeGroupRenameRequest.java
@@ -1,0 +1,12 @@
+package com.tripmoa.notice.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NoticeGroupRenameRequest(
+
+        @NotBlank(message = "그룹명은 필수입니다.")
+        @Size(max = 60, message = "그룹명은 60자 이하여야 합니다.")
+        String name
+) {
+}

--- a/src/main/java/com/tripmoa/notice/dto/request/NoticeItemCreateRequest.java
+++ b/src/main/java/com/tripmoa/notice/dto/request/NoticeItemCreateRequest.java
@@ -1,0 +1,26 @@
+package com.tripmoa.notice.dto.request;
+
+import com.tripmoa.notice.enums.NoticeColor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record NoticeItemCreateRequest(
+
+        @NotNull(message = "공지 그룹 ID는 필수입니다.")
+        Long noticeGroupId,
+
+        @NotNull(message = "색상은 필수입니다.")
+        NoticeColor color,
+
+        @Size(max = 50, message = "태그는 50자 이하여야 합니다.")
+        String tag,
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 100, message = "제목은 100자 이하여야 합니다.")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/tripmoa/notice/dto/request/NoticeItemUpdateRequest.java
+++ b/src/main/java/com/tripmoa/notice/dto/request/NoticeItemUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.tripmoa.notice.dto.request;
+
+import com.tripmoa.notice.enums.NoticeColor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record NoticeItemUpdateRequest(
+
+        @NotNull(message = "공지 그룹 ID는 필수입니다.")
+        Long noticeGroupId,
+
+        @NotNull(message = "색상은 필수입니다.")
+        NoticeColor color,
+
+        @Size(max = 50, message = "태그는 50자 이하여야 합니다.")
+        String tag,
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 100, message = "제목은 100자 이하여야 합니다.")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/tripmoa/notice/dto/response/NoticeGroupResponse.java
+++ b/src/main/java/com/tripmoa/notice/dto/response/NoticeGroupResponse.java
@@ -1,0 +1,27 @@
+package com.tripmoa.notice.dto.response;
+
+import com.tripmoa.notice.entity.NoticeGroup;
+
+import java.time.LocalDateTime;
+
+public record NoticeGroupResponse(
+        Long groupId,
+        Long tripId,
+        String name,
+        boolean isDefault,
+        Integer sortOrder,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static NoticeGroupResponse from(NoticeGroup noticeGroup) {
+        return new NoticeGroupResponse(
+                noticeGroup.getId(),
+                noticeGroup.getTrip().getId(),
+                noticeGroup.getName(),
+                noticeGroup.isDefault(),
+                noticeGroup.getSortOrder(),
+                noticeGroup.getCreatedAt(),
+                noticeGroup.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/tripmoa/notice/dto/response/NoticeItemResponse.java
+++ b/src/main/java/com/tripmoa/notice/dto/response/NoticeItemResponse.java
@@ -1,0 +1,36 @@
+package com.tripmoa.notice.dto.response;
+
+import com.tripmoa.notice.enums.NoticeColor;
+import com.tripmoa.notice.entity.NoticeItem;
+
+import java.time.LocalDateTime;
+
+public record NoticeItemResponse(
+        Long noticeItemId,
+        Long noticeGroupId,
+        Long createdByUserId,
+        Long updatedByUserId,
+        NoticeColor color,
+        String tag,
+        String title,
+        String content,
+        boolean isPinned,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static NoticeItemResponse from(NoticeItem noticeItem) {
+        return new NoticeItemResponse(
+                noticeItem.getId(),
+                noticeItem.getNoticeGroup().getId(),
+                noticeItem.getCreatedByUser().getId(),
+                noticeItem.getUpdatedByUser() != null ? noticeItem.getUpdatedByUser().getId() : null,
+                noticeItem.getColor(),
+                noticeItem.getTag(),
+                noticeItem.getTitle(),
+                noticeItem.getContent(),
+                noticeItem.isPinned(),
+                noticeItem.getCreatedAt(),
+                noticeItem.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/tripmoa/notice/dto/response/NoticeTagResponse.java
+++ b/src/main/java/com/tripmoa/notice/dto/response/NoticeTagResponse.java
@@ -1,0 +1,21 @@
+package com.tripmoa.notice.dto.response;
+
+import com.tripmoa.notice.entity.NoticeTag;
+
+import java.time.LocalDateTime;
+
+public record NoticeTagResponse(
+        Long tagId,
+        Long tripId,
+        String name,
+        LocalDateTime createdAt
+) {
+    public static NoticeTagResponse from(NoticeTag noticeTag) {
+        return new NoticeTagResponse(
+                noticeTag.getId(),
+                noticeTag.getTrip().getId(),
+                noticeTag.getName(),
+                noticeTag.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/tripmoa/notice/entity/NoticeGroup.java
+++ b/src/main/java/com/tripmoa/notice/entity/NoticeGroup.java
@@ -1,0 +1,103 @@
+package com.tripmoa.notice.entity;
+
+import com.tripmoa.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "notice_group",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_notice_group_trip_name",
+                        columnNames = {"trip_id", "name"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_notice_group_trip", columnList = "trip_id"),
+                @Index(name = "idx_notice_group_trip_sort", columnList = "trip_id, sort_order")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 소속 여행
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "trip_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_notice_group_trip")
+    )
+    private Trip trip;
+
+    /**
+     * 그룹명 (예: TRIP NOTICE)
+     */
+    @Column(name = "name", nullable = false, length = 60)
+    private String name;
+
+    /**
+     * 기본 그룹 여부
+     */
+    @Column(name = "is_default", nullable = false)
+    private boolean isDefault = false;
+
+    /**
+     * 정렬 순서
+     */
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder = 0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public NoticeGroup(Trip trip, String name, boolean isDefault, Integer sortOrder) {
+        this.trip = trip;
+        this.name = name;
+        this.isDefault = isDefault;
+        this.sortOrder = sortOrder;
+    }
+
+    public static NoticeGroup createDefault(Trip trip) {
+        return new NoticeGroup(trip, "TRIP NOTICE", true, 0);
+    }
+
+    public static NoticeGroup create(Trip trip, String name, Integer sortOrder) {
+        return new NoticeGroup(trip, name, false, sortOrder);
+    }
+
+    public void rename(String name) {
+        this.name = name;
+    }
+
+    public void changeSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/tripmoa/notice/entity/NoticeItem.java
+++ b/src/main/java/com/tripmoa/notice/entity/NoticeItem.java
@@ -1,0 +1,149 @@
+package com.tripmoa.notice.entity;
+
+import com.tripmoa.notice.enums.NoticeColor;
+import com.tripmoa.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "notice_item",
+        indexes = {
+                @Index(name = "idx_notice_item_group", columnList = "notice_group_id"),
+                @Index(name = "idx_notice_item_group_created", columnList = "notice_group_id, created_at"),
+                @Index(name = "idx_notice_item_creator", columnList = "created_by_user_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 소속 공지 그룹
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "notice_group_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_notice_item_group")
+    )
+    private NoticeGroup noticeGroup;
+
+    /**
+     * 생성자
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "created_by_user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_notice_item_created_by")
+    )
+    private User createdByUser;
+
+    /**
+     * 최종 수정자
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "updated_by_user_id",
+            foreignKey = @ForeignKey(name = "fk_notice_item_updated_by")
+    )
+    private User updatedByUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "color", nullable = false, length = 10)
+    private NoticeColor color = NoticeColor.WHITE;
+
+    @Column(name = "tag", length = 50)
+    private String tag;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "is_pinned", nullable = false)
+    private boolean isPinned = false;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public NoticeItem(
+            NoticeGroup noticeGroup,
+            User createdByUser,
+            NoticeColor color,
+            String tag,
+            String title,
+            String content
+    ) {
+        this.noticeGroup = noticeGroup;
+        this.createdByUser = createdByUser;
+        this.color = color;
+        this.tag = tag;
+        this.title = title;
+        this.content = content;
+    }
+
+    public static NoticeItem create(
+            NoticeGroup noticeGroup,
+            User createdByUser,
+            NoticeColor color,
+            String tag,
+            String title,
+            String content
+    ) {
+        return new NoticeItem(noticeGroup, createdByUser, color, tag, title, content);
+    }
+
+    public void update(
+            NoticeColor color,
+            String tag,
+            String title,
+            String content,
+            User updatedByUser
+    ) {
+        this.color = color;
+        this.tag = tag;
+        this.title = title;
+        this.content = content;
+        this.updatedByUser = updatedByUser;
+    }
+
+    public void moveGroup(NoticeGroup noticeGroup, User updatedByUser) {
+        this.noticeGroup = noticeGroup;
+        this.updatedByUser = updatedByUser;
+    }
+
+    public void pin() {
+        this.isPinned = true;
+    }
+
+    public void unpin() {
+        this.isPinned = false;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/tripmoa/notice/entity/NoticeTag.java
+++ b/src/main/java/com/tripmoa/notice/entity/NoticeTag.java
@@ -1,0 +1,65 @@
+package com.tripmoa.notice.entity;
+
+import com.tripmoa.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "notice_tag",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_notice_tag_trip_name",
+                        columnNames = {"trip_id", "name"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_notice_tag_trip", columnList = "trip_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 소속 여행
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "trip_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_notice_tag_trip")
+    )
+    private Trip trip;
+
+    /**
+     * 태그명
+     */
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public NoticeTag(Trip trip, String name) {
+        this.trip = trip;
+        this.name = name;
+    }
+
+    public static NoticeTag create(Trip trip, String name) {
+        return new NoticeTag(trip, name);
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/tripmoa/notice/enums/NoticeColor.java
+++ b/src/main/java/com/tripmoa/notice/enums/NoticeColor.java
@@ -1,0 +1,8 @@
+package com.tripmoa.notice.enums;
+
+public enum NoticeColor {
+    WHITE,
+    YELLOW,
+    BLUE,
+    GREEN
+}

--- a/src/main/java/com/tripmoa/notice/repository/NoticeGroupRepository.java
+++ b/src/main/java/com/tripmoa/notice/repository/NoticeGroupRepository.java
@@ -1,0 +1,41 @@
+package com.tripmoa.notice.repository;
+
+import com.tripmoa.notice.entity.NoticeGroup;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoticeGroupRepository extends JpaRepository<NoticeGroup, Long> {
+
+    /**
+     * 특정 여행의 공지 그룹 전체 조회
+     * - 정렬 순서 오름차순, 생성일 오름차순
+     */
+    @EntityGraph(attributePaths = {"trip"})
+    List<NoticeGroup> findByTrip_IdOrderBySortOrderAscCreatedAtAsc(Long tripId);
+
+    /**
+     * 특정 여행의 공지 그룹 단건 조회
+     */
+    @EntityGraph(attributePaths = {"trip"})
+    Optional<NoticeGroup> findByIdAndTrip_Id(Long groupId, Long tripId);
+
+    /**
+     * 특정 여행 내 동일한 그룹명 존재 여부 확인
+     */
+    boolean existsByTrip_IdAndName(Long tripId, String name);
+
+    /**
+     * 특정 여행 내 동일한 그룹명 존재 여부 확인
+     * - 수정 시 자기 자신 제외
+     */
+    boolean existsByTrip_IdAndNameAndIdNot(Long tripId, String name, Long groupId);
+
+    /**
+     * 특정 여행의 기본 그룹 조회
+     */
+    @EntityGraph(attributePaths = {"trip"})
+    Optional<NoticeGroup> findByTrip_IdAndIsDefaultTrue(Long tripId);
+}

--- a/src/main/java/com/tripmoa/notice/repository/NoticeItemRepository.java
+++ b/src/main/java/com/tripmoa/notice/repository/NoticeItemRepository.java
@@ -1,0 +1,33 @@
+package com.tripmoa.notice.repository;
+
+import com.tripmoa.notice.entity.NoticeItem;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoticeItemRepository extends JpaRepository<NoticeItem, Long> {
+
+    /**
+     * 특정 여행 + 특정 그룹의 공지 메모 전체 조회
+     * - 고정된 메모 우선, 이후 최신순
+     */
+    @EntityGraph(attributePaths = {"noticeGroup", "noticeGroup.trip", "createdByUser", "updatedByUser"})
+    List<NoticeItem> findByNoticeGroup_Trip_IdAndNoticeGroup_IdOrderByIsPinnedDescCreatedAtDesc(
+            Long tripId,
+            Long noticeGroupId
+    );
+
+    /**
+     * 특정 여행의 공지 메모 단건 조회
+     */
+    @EntityGraph(attributePaths = {"noticeGroup", "noticeGroup.trip", "createdByUser", "updatedByUser"})
+    Optional<NoticeItem> findByIdAndNoticeGroup_Trip_Id(Long noticeItemId, Long tripId);
+
+    /**
+     * 특정 그룹에 속한 공지 메모 개수
+     * - 그룹 삭제 가능 여부 판단 등에 사용 가능
+     */
+    long countByNoticeGroup_Id(Long noticeGroupId);
+}

--- a/src/main/java/com/tripmoa/notice/repository/NoticeTagRepository.java
+++ b/src/main/java/com/tripmoa/notice/repository/NoticeTagRepository.java
@@ -1,0 +1,35 @@
+package com.tripmoa.notice.repository;
+
+import com.tripmoa.notice.entity.NoticeTag;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoticeTagRepository extends JpaRepository<NoticeTag, Long> {
+
+    /**
+     * 특정 여행의 최근 사용 태그 조회
+     * - 생성일 최신순
+     */
+    @EntityGraph(attributePaths = {"trip"})
+    List<NoticeTag> findTop10ByTrip_IdOrderByCreatedAtDesc(Long tripId);
+
+    /**
+     * 특정 여행 내 태그명 존재 여부 확인
+     */
+    boolean existsByTrip_IdAndName(Long tripId, String name);
+
+    /**
+     * 특정 여행 + 태그명 단건 조회
+     */
+    @EntityGraph(attributePaths = {"trip"})
+    Optional<NoticeTag> findByTrip_IdAndName(Long tripId, String name);
+
+    /**
+     * 특정 여행의 전체 태그 목록 조회
+     */
+    @EntityGraph(attributePaths = {"trip"})
+    List<NoticeTag> findByTrip_IdOrderByCreatedAtDesc(Long tripId);
+}

--- a/src/main/java/com/tripmoa/notice/service/NoticeGroupService.java
+++ b/src/main/java/com/tripmoa/notice/service/NoticeGroupService.java
@@ -1,0 +1,129 @@
+package com.tripmoa.notice.service;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.notice.dto.request.NoticeGroupCreateRequest;
+import com.tripmoa.notice.dto.request.NoticeGroupRenameRequest;
+import com.tripmoa.notice.dto.response.NoticeGroupResponse;
+import com.tripmoa.notice.entity.NoticeGroup;
+import com.tripmoa.notice.repository.NoticeGroupRepository;
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.service.TripPermissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeGroupService {
+
+    private final NoticeGroupRepository noticeGroupRepository;
+    private final TripPermissionService tripPermissionService;
+
+    /**
+     * 공지 그룹 전체 조회
+     * - 여행 멤버 이상 접근 가능
+     */
+    public List<NoticeGroupResponse> getNoticeGroups(Long tripId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        return noticeGroupRepository.findByTrip_IdOrderBySortOrderAscCreatedAtAsc(tripId)
+                .stream()
+                .map(NoticeGroupResponse::from)
+                .toList();
+    }
+
+    /**
+     * 공지 그룹 단건 조회
+     * - 여행 멤버 이상 접근 가능
+     */
+    public NoticeGroupResponse getNoticeGroup(Long tripId, Long groupId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        NoticeGroup noticeGroup = getNoticeGroupOrThrow(tripId, groupId);
+        return NoticeGroupResponse.from(noticeGroup);
+    }
+
+    /**
+     * 공지 그룹 생성
+     * - 소유주만 가능
+     */
+    @Transactional
+    public NoticeGroupResponse createNoticeGroup(Long tripId, Long userId, NoticeGroupCreateRequest request) {
+        tripPermissionService.assertOwner(tripId, userId);
+
+        String name = request.name().trim();
+        validateDuplicateGroupName(tripId, name);
+
+        Trip trip = tripPermissionService.getTripOr404(tripId);
+
+        NoticeGroup noticeGroup = NoticeGroup.create(
+                trip,
+                name,
+                request.sortOrder() != null ? request.sortOrder() : 0
+        );
+
+        noticeGroupRepository.save(noticeGroup);
+        return NoticeGroupResponse.from(noticeGroup);
+    }
+
+    /**
+     * 공지 그룹 이름 수정
+     * - 소유주만 가능
+     * - 기본 그룹(TRIP NOTICE)은 이름 수정 불가
+     */
+    @Transactional
+    public NoticeGroupResponse renameNoticeGroup(Long tripId, Long groupId, Long userId, NoticeGroupRenameRequest request) {
+        tripPermissionService.assertOwner(tripId, userId);
+
+        NoticeGroup noticeGroup = getNoticeGroupOrThrow(tripId, groupId);
+
+        if (noticeGroup.isDefault()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "기본 공지 그룹은 이름을 수정할 수 없습니다.");
+        }
+
+        String name = request.name().trim();
+        validateDuplicateGroupNameForUpdate(tripId, groupId, name);
+
+        noticeGroup.rename(name);
+        return NoticeGroupResponse.from(noticeGroup);
+    }
+
+    /**
+     * 공지 그룹 삭제
+     * - 소유주만 가능
+     * - 기본 그룹(TRIP NOTICE)은 삭제 불가
+     */
+    @Transactional
+    public void deleteNoticeGroup(Long tripId, Long groupId, Long userId) {
+        tripPermissionService.assertOwner(tripId, userId);
+
+        NoticeGroup noticeGroup = getNoticeGroupOrThrow(tripId, groupId);
+
+        if (noticeGroup.isDefault()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "기본 공지 그룹은 삭제할 수 없습니다.");
+        }
+
+        noticeGroupRepository.delete(noticeGroup);
+    }
+
+    private NoticeGroup getNoticeGroupOrThrow(Long tripId, Long groupId) {
+        return noticeGroupRepository.findByIdAndTrip_Id(groupId, tripId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_GROUP_NOT_FOUND));
+    }
+
+    private void validateDuplicateGroupName(Long tripId, String name) {
+        if (noticeGroupRepository.existsByTrip_IdAndName(tripId, name)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NOTICE_GROUP_NAME);
+        }
+    }
+
+    private void validateDuplicateGroupNameForUpdate(Long tripId, Long groupId, String name) {
+        if (noticeGroupRepository.existsByTrip_IdAndNameAndIdNot(tripId, name, groupId)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NOTICE_GROUP_NAME);
+        }
+    }
+}

--- a/src/main/java/com/tripmoa/notice/service/NoticeItemService.java
+++ b/src/main/java/com/tripmoa/notice/service/NoticeItemService.java
@@ -1,0 +1,237 @@
+package com.tripmoa.notice.service;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.notice.dto.request.NoticeItemCreateRequest;
+import com.tripmoa.notice.dto.request.NoticeItemUpdateRequest;
+import com.tripmoa.notice.dto.response.NoticeItemResponse;
+import com.tripmoa.notice.dto.response.NoticeTagResponse;
+import com.tripmoa.notice.entity.NoticeGroup;
+import com.tripmoa.notice.entity.NoticeItem;
+import com.tripmoa.notice.entity.NoticeTag;
+import com.tripmoa.notice.enums.NoticeColor;
+import com.tripmoa.notice.repository.NoticeGroupRepository;
+import com.tripmoa.notice.repository.NoticeItemRepository;
+import com.tripmoa.notice.repository.NoticeTagRepository;
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.service.TripPermissionService;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeItemService {
+
+    private final NoticeItemRepository noticeItemRepository;
+    private final NoticeGroupRepository noticeGroupRepository;
+    private final NoticeTagRepository noticeTagRepository;
+    private final TripPermissionService tripPermissionService;
+    private final UserRepository userRepository;
+
+    /**
+     * 공지 메모 전체 조회
+     * - 여행 멤버 이상 접근 가능
+     */
+    public List<NoticeItemResponse> getNoticeItems(Long tripId, Long groupId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        NoticeGroup noticeGroup = getNoticeGroupOrThrow(tripId, groupId);
+
+        return noticeItemRepository
+                .findByNoticeGroup_Trip_IdAndNoticeGroup_IdOrderByIsPinnedDescCreatedAtDesc(
+                        tripId,
+                        noticeGroup.getId()
+                )
+                .stream()
+                .map(NoticeItemResponse::from)
+                .toList();
+    }
+
+    /**
+     * 공지 메모 단건 조회
+     * - 여행 멤버 이상 접근 가능
+     */
+    public NoticeItemResponse getNoticeItem(Long tripId, Long noticeItemId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        NoticeItem noticeItem = getNoticeItemOrThrow(tripId, noticeItemId);
+        return NoticeItemResponse.from(noticeItem);
+    }
+
+    /**
+     * 공지 메모 생성
+     * - 여행 멤버 이상 가능
+     */
+    @Transactional
+    public NoticeItemResponse createNoticeItem(Long tripId, Long userId, NoticeItemCreateRequest request) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        NoticeGroup noticeGroup = getNoticeGroupOrThrow(tripId, request.noticeGroupId());
+        User user = getUserOrThrow(userId);
+
+        NoticeColor color = request.color() != null ? request.color() : NoticeColor.WHITE;
+        String tag = normalizeTag(request.tag());
+        String title = request.title().trim();
+        String content = request.content().trim();
+
+        NoticeItem noticeItem = NoticeItem.create(
+                noticeGroup,
+                user,
+                color,
+                tag,
+                title,
+                content
+        );
+
+        noticeItemRepository.save(noticeItem);
+        saveTagIfNeeded(tripId, tag);
+
+        return NoticeItemResponse.from(noticeItem);
+    }
+
+    /**
+     * 공지 메모 수정
+     * - 여행 멤버 이상 가능
+     */
+    @Transactional
+    public NoticeItemResponse updateNoticeItem(Long tripId, Long noticeItemId, Long userId, NoticeItemUpdateRequest request) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        NoticeItem noticeItem = getNoticeItemOrThrow(tripId, noticeItemId);
+        NoticeGroup targetGroup = getNoticeGroupOrThrow(tripId, request.noticeGroupId());
+        User user = getUserOrThrow(userId);
+
+        if (!noticeItem.getNoticeGroup().getId().equals(targetGroup.getId())) {
+            noticeItem.moveGroup(targetGroup, user);
+        }
+
+        String tag = normalizeTag(request.tag());
+
+        noticeItem.update(
+                request.color(),
+                tag,
+                request.title().trim(),
+                request.content().trim(),
+                user
+        );
+
+        saveTagIfNeeded(tripId, tag);
+
+        return NoticeItemResponse.from(noticeItem);
+    }
+
+    /**
+     * 공지 메모 삭제
+     * - 여행 소유주만 가능
+     */
+    @Transactional
+    public void deleteNoticeItem(Long tripId, Long noticeItemId, Long userId) {
+        tripPermissionService.assertOwner(tripId, userId);
+
+        NoticeItem noticeItem = getNoticeItemOrThrow(tripId, noticeItemId);
+        noticeItemRepository.delete(noticeItem);
+    }
+
+    /**
+     * 공지 메모 핀 고정
+     * - 여행 멤버 이상 가능
+     */
+    @Transactional
+    public NoticeItemResponse pinNoticeItem(Long tripId, Long noticeItemId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        NoticeItem noticeItem = getNoticeItemOrThrow(tripId, noticeItemId);
+        noticeItem.pin();
+
+        return NoticeItemResponse.from(noticeItem);
+    }
+
+    /**
+     * 공지 메모 핀 해제
+     * - 여행 소유주만 가능
+     */
+    @Transactional
+    public NoticeItemResponse unpinNoticeItem(Long tripId, Long noticeItemId, Long userId) {
+        tripPermissionService.assertOwner(tripId, userId);
+
+        NoticeItem noticeItem = getNoticeItemOrThrow(tripId, noticeItemId);
+        noticeItem.unpin();
+
+        return NoticeItemResponse.from(noticeItem);
+    }
+
+    /**
+     * 최근 사용 태그 조회
+     * - 여행 멤버 이상 접근 가능
+     */
+    public List<NoticeTagResponse> getRecentNoticeTags(Long tripId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        return noticeTagRepository.findTop10ByTrip_IdOrderByCreatedAtDesc(tripId)
+                .stream()
+                .map(NoticeTagResponse::from)
+                .toList();
+    }
+
+    /**
+     * 태그 삭제
+     * - 여행 소유주만 가능
+     */
+    @Transactional
+    public void deleteNoticeTag(Long tripId, Long tagId, Long userId) {
+        tripPermissionService.assertOwner(tripId, userId);
+
+        NoticeTag noticeTag = noticeTagRepository.findById(tagId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_TAG_NOT_FOUND));
+
+        if (!noticeTag.getTrip().getId().equals(tripId)) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "해당 여행의 공지 태그가 아닙니다.");
+        }
+
+        noticeTagRepository.delete(noticeTag);
+    }
+
+    private NoticeItem getNoticeItemOrThrow(Long tripId, Long noticeItemId) {
+        return noticeItemRepository.findByIdAndNoticeGroup_Trip_Id(noticeItemId, tripId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_ITEM_NOT_FOUND));
+    }
+
+    private NoticeGroup getNoticeGroupOrThrow(Long tripId, Long groupId) {
+        return noticeGroupRepository.findByIdAndTrip_Id(groupId, tripId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTICE_GROUP_NOT_FOUND));
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private String normalizeTag(String tag) {
+        if (tag == null) {
+            return null;
+        }
+
+        String normalized = tag.trim();
+        return normalized.isBlank() ? null : normalized;
+    }
+
+    private void saveTagIfNeeded(Long tripId, String normalizedTag) {
+        if (normalizedTag == null) {
+            return;
+        }
+
+        if (noticeTagRepository.existsByTrip_IdAndName(tripId, normalizedTag)) {
+            return;
+        }
+
+        Trip trip = tripPermissionService.getTripOr404(tripId);
+        NoticeTag noticeTag = NoticeTag.create(trip, normalizedTag);
+        noticeTagRepository.save(noticeTag);
+    }
+}

--- a/src/main/java/com/tripmoa/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tripmoa/security/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package com.tripmoa.security.jwt;
 
-import com.tripmoa.security.princpal.CustomUserDetails;
-import com.tripmoa.security.princpal.CustomUserDetailsService;
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetailsService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/tripmoa/security/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/tripmoa/security/jwt/JwtAuthenticationProvider.java
@@ -1,7 +1,7 @@
 package com.tripmoa.security.jwt;
 
-import com.tripmoa.security.princpal.CustomUserDetails;
-import com.tripmoa.security.princpal.CustomUserDetailsService;
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetailsService;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/tripmoa/security/principal/CustomUserDetails.java
+++ b/src/main/java/com/tripmoa/security/principal/CustomUserDetails.java
@@ -1,4 +1,4 @@
-package com.tripmoa.security.princpal;
+package com.tripmoa.security.principal;
 
 import com.tripmoa.user.entity.User;
 import com.tripmoa.user.enums.UserStatus;

--- a/src/main/java/com/tripmoa/security/principal/CustomUserDetailsService.java
+++ b/src/main/java/com/tripmoa/security/principal/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package com.tripmoa.security.princpal;
+package com.tripmoa.security.principal;
 
 import com.tripmoa.user.entity.User;
 import com.tripmoa.user.repository.UserRepository;

--- a/src/main/java/com/tripmoa/trip/controller/TripController.java
+++ b/src/main/java/com/tripmoa/trip/controller/TripController.java
@@ -1,6 +1,6 @@
 package com.tripmoa.trip.controller;
 
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import com.tripmoa.trip.dto.*;
 import com.tripmoa.trip.enums.TripStatus;
 import com.tripmoa.trip.enums.TripVisibility;

--- a/src/main/java/com/tripmoa/trip/service/TripCommandService.java
+++ b/src/main/java/com/tripmoa/trip/service/TripCommandService.java
@@ -7,6 +7,13 @@ import com.tripmoa.expense.enums.SplitRemainderPolicy;
 import com.tripmoa.expense.repository.SettlementSettingRepository;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.notice.entity.NoticeGroup;
+import com.tripmoa.notice.entity.NoticeItem;
+import com.tripmoa.notice.entity.NoticeTag;
+import com.tripmoa.notice.enums.NoticeColor;
+import com.tripmoa.notice.repository.NoticeGroupRepository;
+import com.tripmoa.notice.repository.NoticeItemRepository;
+import com.tripmoa.notice.repository.NoticeTagRepository;
 import com.tripmoa.trip.dto.*;
 import com.tripmoa.trip.entity.Trip;
 import com.tripmoa.trip.entity.TripMember;
@@ -33,6 +40,9 @@ public class TripCommandService {
     private final TripPermissionService tripPermissionService;
     private final UserRepository userRepository;
     private final SettlementSettingRepository settlementSettingRepository;
+    private final NoticeGroupRepository noticeGroupRepository;
+    private final NoticeItemRepository noticeItemRepository;
+    private final NoticeTagRepository noticeTagRepository;
 
     // 여행 생성
     public TripDetailResponse createTrip(Long userId, TripCreateRequest request) {
@@ -83,6 +93,97 @@ public class TripCommandService {
                 .build();
 
         Trip savedTrip = tripRepository.save(trip);
+
+        // 기본 공지 그룹 생성
+        NoticeGroup defaultNoticeGroup = NoticeGroup.createDefault(savedTrip);
+        noticeGroupRepository.save(defaultNoticeGroup);
+
+        // 기본 공지 4개 생성
+        List<NoticeItem> defaultNoticeItems = List.of(
+                NoticeItem.create(
+                        defaultNoticeGroup,
+                        owner,
+                        NoticeColor.YELLOW,
+                        "준비물",
+                        "여행 준비물 체크리스트",
+                        """
+                        여행 전 필요한 준비물을 미리 확인해주세요.
+        
+                        - 신분증 / 여권
+                        - 충전기 / 보조배터리
+                        - 세면도구 / 개인 상비약
+                        - 옷 / 우산 / 계절용품
+                        - 현금 / 카드 / 교통수단 예매 확인
+        
+                        출발 전날 한 번 더 체크해주세요.
+                        """
+                ),
+                NoticeItem.create(
+                        defaultNoticeGroup,
+                        owner,
+                        NoticeColor.BLUE,
+                        "연락처",
+                        "비상 연락처",
+                        """
+                        긴급 상황에 대비해 주요 연락처를 정리해주세요.
+        
+                        - 숙소 연락처
+                        - 병원 / 약국
+                        - 경찰서 / 긴급 신고 번호
+                        - 차량 렌트 / 보험사
+                        - 여행 멤버 비상 연락처
+        
+                        필요한 번호는 여행 전 미리 공유해주세요.
+                        """
+                ),
+                NoticeItem.create(
+                        defaultNoticeGroup,
+                        owner,
+                        NoticeColor.GREEN,
+                        "예약",
+                        "일정 및 예약 유의사항",
+                        """
+                        예약 및 일정 변경 사항은 모든 멤버가 확인할 수 있게 공유해주세요.
+        
+                        - 숙소 체크인 / 체크아웃 시간 확인
+                        - 기차 / 버스 / 항공권 시간 재확인
+                        - 입장권 / 예약 바우처 보관
+                        - 지각 방지를 위해 출발 시간 10분 전 도착 권장
+        
+                        일정 변경 시 공지사항에 바로 남겨주세요.
+                        """
+                ),
+                NoticeItem.create(
+                        defaultNoticeGroup,
+                        owner,
+                        NoticeColor.WHITE,
+                        "안전",
+                        "안전 주의사항",
+                        """
+                        안전한 여행을 위해 아래 내용을 확인해주세요.
+        
+                        - 늦은 시간 단독 이동 주의
+                        - 귀중품 분실 주의
+                        - 낯선 장소에서는 위치 공유 권장
+                        - 무리한 일정 진행 금지
+                        - 비상 상황 시 바로 연락 후 함께 대응
+        
+                        모두가 안전하게 여행할 수 있도록 서로 확인해주세요.
+                        """
+                )
+        );
+
+        noticeItemRepository.saveAll(defaultNoticeItems);
+
+        // 기본 태그 생성
+        List<String> defaultTags = List.of("준비물", "연락처", "예약", "안전");
+
+        List<NoticeTag> noticeTags = defaultTags.stream()
+                .distinct()
+                .map(tag -> NoticeTag.create(savedTrip, tag))
+                .toList();
+
+        noticeTagRepository.saveAll(noticeTags);
 
         // 정산 설정 기본값 생성
         SettlementSetting setting = SettlementSetting.builder()

--- a/src/main/java/com/tripmoa/user/controller/UserController.java
+++ b/src/main/java/com/tripmoa/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.tripmoa.user.controller;
 
-import com.tripmoa.security.princpal.CustomUserDetails;
+import com.tripmoa.security.principal.CustomUserDetails;
 import com.tripmoa.user.dto.CheckEmailRequest;
 import com.tripmoa.user.dto.CheckEmailResponse;
 import com.tripmoa.user.dto.UserResponseDto;

--- a/src/main/java/com/tripmoa/user/service/UserService.java
+++ b/src/main/java/com/tripmoa/user/service/UserService.java
@@ -55,7 +55,6 @@ public class UserService {
                         .build());
     }
 
-    // UserService 내 업데이트 로직 예시
     @Transactional
     public void updateUserInfo(Long userId, UserUpdateRequestDto dto) {
         User user = userRepository.findById(userId).orElseThrow();

--- a/src/main/java/com/tripmoa/voucher/controller/VoucherController.java
+++ b/src/main/java/com/tripmoa/voucher/controller/VoucherController.java
@@ -1,0 +1,77 @@
+package com.tripmoa.voucher.controller;
+
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.voucher.dto.VoucherCreateRequest;
+import com.tripmoa.voucher.dto.VoucherUpdateRequest;
+import com.tripmoa.voucher.dto.VoucherResponse;
+import com.tripmoa.voucher.service.VoucherService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trips/{tripId}/vouchers")
+public class VoucherController {
+
+    private final VoucherService voucherService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<VoucherResponse> createVoucher(
+            @PathVariable Long tripId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestPart("request") VoucherCreateRequest request,
+            @RequestPart("file") MultipartFile file
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(voucherService.create(tripId, userId, request, file));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<VoucherResponse>> getVouchers(
+            @PathVariable Long tripId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(voucherService.getVouchers(tripId, userId));
+    }
+
+    @GetMapping("/{voucherId}")
+    public ResponseEntity<VoucherResponse> getVoucher(
+            @PathVariable Long tripId,
+            @PathVariable Long voucherId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(voucherService.getVoucher(tripId, voucherId, userId));
+    }
+
+    @PutMapping(value = "/{voucherId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<VoucherResponse> updateVoucher(
+            @PathVariable Long tripId,
+            @PathVariable Long voucherId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestPart("request") VoucherUpdateRequest request,
+            @RequestPart(value = "file", required = false) MultipartFile file
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(voucherService.update(tripId, voucherId, userId, request, file));
+    }
+
+    @DeleteMapping("/{voucherId}")
+    public ResponseEntity<Void> deleteVoucher(
+            @PathVariable Long tripId,
+            @PathVariable Long voucherId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        voucherService.delete(tripId, voucherId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/tripmoa/voucher/dto/VoucherCreateRequest.java
+++ b/src/main/java/com/tripmoa/voucher/dto/VoucherCreateRequest.java
@@ -1,0 +1,19 @@
+package com.tripmoa.voucher.dto;
+
+import com.tripmoa.voucher.enums.VoucherType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record VoucherCreateRequest(
+        @NotNull
+        VoucherType type,
+
+        @NotBlank
+        @Size(max = 100)
+        String title,
+
+        @Size(max = 255)
+        String description
+) {
+}

--- a/src/main/java/com/tripmoa/voucher/dto/VoucherResponse.java
+++ b/src/main/java/com/tripmoa/voucher/dto/VoucherResponse.java
@@ -1,0 +1,38 @@
+package com.tripmoa.voucher.dto;
+
+import com.tripmoa.voucher.entity.Voucher;
+import com.tripmoa.voucher.enums.VoucherType;
+
+import java.time.LocalDateTime;
+
+public record VoucherResponse(
+        Long voucherId,
+        Long tripId,
+        VoucherType type,
+        String title,
+        String description,
+        String fileUrl,
+        String fileName,
+        String fileType,
+        Long fileSize,
+        Long createdByUserId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static VoucherResponse from(Voucher voucher) {
+        return new VoucherResponse(
+                voucher.getId(),
+                voucher.getTrip().getId(),
+                voucher.getType(),
+                voucher.getTitle(),
+                voucher.getDescription(),
+                voucher.getFileUrl(),
+                voucher.getFileName(),
+                voucher.getFileType().name(),
+                voucher.getFileSize(),
+                voucher.getCreatedByUser() != null ? voucher.getCreatedByUser().getId() : null,
+                voucher.getCreatedAt(),
+                voucher.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/tripmoa/voucher/dto/VoucherUpdateRequest.java
+++ b/src/main/java/com/tripmoa/voucher/dto/VoucherUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.tripmoa.voucher.dto;
+
+import com.tripmoa.voucher.enums.VoucherType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record VoucherUpdateRequest(
+        @NotNull
+        VoucherType type,
+
+        @NotBlank
+        @Size(max = 100)
+        String title,
+
+        @Size(max = 255)
+        String description
+) {
+}

--- a/src/main/java/com/tripmoa/voucher/entity/Voucher.java
+++ b/src/main/java/com/tripmoa/voucher/entity/Voucher.java
@@ -1,0 +1,128 @@
+package com.tripmoa.voucher.entity;
+
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.voucher.enums.VoucherFileType;
+import com.tripmoa.voucher.enums.VoucherType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "voucher",
+        indexes = {
+                @Index(name = "idx_voucher_trip", columnList = "trip_id"),
+                @Index(name = "idx_voucher_trip_type", columnList = "trip_id, type"),
+                @Index(name = "idx_voucher_created_by", columnList = "created_by_user_id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Voucher {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 바우처 유형
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private VoucherType type;
+
+    // 바우처 제목
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    // 바우처 설명
+    @Column(name = "description", length = 255)
+    private String description;
+
+    // 업로드 파일 접근 경로
+    @Column(name = "file_url", length = 500)
+    private String fileUrl;
+
+    // 원본 파일명
+    @Column(name = "file_name", length = 255)
+    private String fileName;
+
+    // 파일 타입
+    @Enumerated(EnumType.STRING)
+    @Column(name = "file_type", nullable = false, length = 20)
+    private VoucherFileType fileType;
+
+    // 파일 크기(byte)
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 바우처가 속한 여행
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "trip_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_voucher_trip"))
+    private Trip trip;
+
+    // 등록한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_user_id",
+            foreignKey = @ForeignKey(name = "fk_voucher_created_by_user"))
+    private User createdByUser;
+
+    // === 메서드 ===
+    @Builder
+    public Voucher(Trip trip,
+                   VoucherType type,
+                   String title,
+                   String description,
+                   String fileUrl,
+                   String fileName,
+                   VoucherFileType fileType,
+                   Long fileSize,
+                   User createdByUser) {
+        this.trip = trip;
+        this.type = type;
+        this.title = title;
+        this.description = description;
+        this.fileUrl = fileUrl;
+        this.fileName = fileName;
+        this.fileType = fileType;
+        this.fileSize = fileSize;
+        this.createdByUser = createdByUser;
+    }
+
+    public void update(VoucherType type,
+                       String title,
+                       String description,
+                       String fileUrl,
+                       String fileName,
+                       VoucherFileType fileType,
+                       Long fileSize) {
+        this.type = type;
+        this.title = title;
+        this.description = description;
+        this.fileUrl = fileUrl;
+        this.fileName = fileName;
+        this.fileType = fileType;
+        this.fileSize = fileSize;
+    }
+
+    public void changeFile(String fileUrl, String fileName, VoucherFileType fileType, Long fileSize) {
+        this.fileUrl = fileUrl;
+        this.fileName = fileName;
+        this.fileType = fileType;
+        this.fileSize = fileSize;
+    }
+}

--- a/src/main/java/com/tripmoa/voucher/enums/VoucherFileType.java
+++ b/src/main/java/com/tripmoa/voucher/enums/VoucherFileType.java
@@ -1,0 +1,7 @@
+package com.tripmoa.voucher.enums;
+
+public enum VoucherFileType {
+    PDF,
+    JPG,
+    IMG
+}

--- a/src/main/java/com/tripmoa/voucher/enums/VoucherType.java
+++ b/src/main/java/com/tripmoa/voucher/enums/VoucherType.java
@@ -1,0 +1,8 @@
+package com.tripmoa.voucher.enums;
+
+public enum VoucherType {
+    AIR,        // 항공권
+    HTL,        // 숙소
+    TKT,        // 입장권/티켓
+    ETC         // 기타
+}

--- a/src/main/java/com/tripmoa/voucher/repository/VoucherRepository.java
+++ b/src/main/java/com/tripmoa/voucher/repository/VoucherRepository.java
@@ -1,0 +1,16 @@
+package com.tripmoa.voucher.repository;
+
+import com.tripmoa.voucher.entity.Voucher;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface VoucherRepository extends JpaRepository<Voucher, Long> {
+
+    // 특정 여행의 바우처 전체 조회 (최신순)
+    List<Voucher> findAllByTrip_IdOrderByCreatedAtDesc(Long tripId);
+
+    // 특정 여행에 속한 특정 바우처 조회
+    Optional<Voucher> findByIdAndTrip_Id(Long voucherId, Long tripId);
+}

--- a/src/main/java/com/tripmoa/voucher/service/VoucherService.java
+++ b/src/main/java/com/tripmoa/voucher/service/VoucherService.java
@@ -1,0 +1,147 @@
+package com.tripmoa.voucher.service;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.global.file.FileDirectories;
+import com.tripmoa.global.file.FileStorageService;
+import com.tripmoa.global.file.StoredFileInfo;
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.service.TripPermissionService;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.repository.UserRepository;
+import com.tripmoa.voucher.dto.VoucherCreateRequest;
+import com.tripmoa.voucher.dto.VoucherResponse;
+import com.tripmoa.voucher.dto.VoucherUpdateRequest;
+import com.tripmoa.voucher.entity.Voucher;
+import com.tripmoa.voucher.enums.VoucherFileType;
+import com.tripmoa.voucher.repository.VoucherRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VoucherService {
+
+    private final VoucherRepository voucherRepository;
+    private final UserRepository userRepository;
+    private final FileStorageService fileStorageService;
+    private final TripPermissionService tripPermissionService;
+
+    @Transactional
+    public VoucherResponse create(Long tripId, Long userId, VoucherCreateRequest request, MultipartFile file) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        Trip trip = tripPermissionService.getTripOr404(tripId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        StoredFileInfo storedFile = fileStorageService.store(file, FileDirectories.VOUCHER);
+
+        Voucher voucher = Voucher.builder()
+                .trip(trip)
+                .type(request.type())
+                .title(request.title())
+                .description(request.description())
+                .fileUrl(storedFile.fileUrl())
+                .fileName(storedFile.originalFileName())
+                .fileType(resolveFileType(file))
+                .fileSize(storedFile.fileSize())
+                .createdByUser(user)
+                .build();
+
+        voucherRepository.save(voucher);
+        return VoucherResponse.from(voucher);
+    }
+
+    public List<VoucherResponse> getVouchers(Long tripId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        return voucherRepository.findAllByTrip_IdOrderByCreatedAtDesc(tripId)
+                .stream()
+                .map(VoucherResponse::from)
+                .toList();
+    }
+
+    public VoucherResponse getVoucher(Long tripId, Long voucherId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        Voucher voucher = voucherRepository.findByIdAndTrip_Id(voucherId, tripId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "바우처를 찾을 수 없습니다."));
+
+        return VoucherResponse.from(voucher);
+    }
+
+    @Transactional
+    public VoucherResponse update(Long tripId, Long voucherId, Long userId,
+                                  VoucherUpdateRequest request, MultipartFile file) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        Voucher voucher = voucherRepository.findByIdAndTrip_Id(voucherId, tripId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "바우처를 찾을 수 없습니다."));
+
+        String fileUrl = voucher.getFileUrl();
+        String fileName = voucher.getFileName();
+        VoucherFileType fileType = voucher.getFileType();
+        Long fileSize = voucher.getFileSize();
+
+        if (file != null && !file.isEmpty()) {
+            StoredFileInfo storedFile = fileStorageService.store(file, FileDirectories.VOUCHER);
+
+            String oldFileUrl = voucher.getFileUrl();
+
+            fileUrl = storedFile.fileUrl();
+            fileName = storedFile.originalFileName();
+            fileType = resolveFileType(file);
+            fileSize = storedFile.fileSize();
+
+            fileStorageService.deleteFile(oldFileUrl);
+        }
+
+        voucher.update(
+                request.type(),
+                request.title(),
+                request.description(),
+                fileUrl,
+                fileName,
+                fileType,
+                fileSize
+        );
+
+        return VoucherResponse.from(voucher);
+    }
+
+    @Transactional
+    public void delete(Long tripId, Long voucherId, Long userId) {
+        tripPermissionService.assertOwner(tripId, userId);
+
+        Voucher voucher = voucherRepository.findByIdAndTrip_Id(voucherId, tripId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "바우처를 찾을 수 없습니다."));
+
+        fileStorageService.deleteFile(voucher.getFileUrl());
+        voucherRepository.delete(voucher);
+    }
+
+    private VoucherFileType resolveFileType(MultipartFile file) {
+        String contentType = file.getContentType();
+
+        if (contentType == null || contentType.isBlank()) {
+            return VoucherFileType.IMG;
+        }
+
+        String normalized = contentType.toLowerCase();
+
+        if (normalized.contains("pdf")) {
+            return VoucherFileType.PDF;
+        }
+        if (normalized.contains("jpeg") || normalized.contains("jpg")) {
+            return VoucherFileType.JPG;
+        }
+        return VoucherFileType.IMG;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,11 @@ spring.application.name=TripMoa
 server.port=8080
 
 ################################
+# \uAC1C\uBC1C \uC11C\uBC84 \uC124\uC815
+################################
+cors.allowed-origins=http://localhost:3000,http://localhost:5173
+
+################################
 # \uC2E4\uD589 \uD504\uB85C\uD30C\uC77C
 ################################
 spring.profiles.active=dev,oauth,secret
@@ -17,13 +22,18 @@ logging.level.org.springframework.security=DEBUG
 ################################
 # \uD30C\uC77C \uC5C5\uB85C\uB4DC \uC124\uC815
 ################################
+file.upload-dir=./uploads/
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
 ################################
-# \uAE30\uD0C0 \uC124\uC815
+# Redis \uC124\uC815
 ################################
-# JSON \uBCF8\uBB38\uC5D0 \uB2F4\uAE34 \uB9E4\uC6B0 \uAE34 \uBB38\uC790\uC5F4\uC744 \uD5C8\uC6A9\uD558\uAE30 \uC704\uD55C \uC124\uC815
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
+################################
+# \uC694\uCCAD/\uC751\uB2F5 \uBCF8\uBB38 \uBC84\uD37C \uD06C\uAE30 \uC81C\uD55C
+################################
 server.tomcat.max-http-form-post-size=10MB
-# \uC694\uCCAD \uC804\uCCB4 \uD06C\uAE30 \uC81C\uD55C (Spring Boot 3.0 \uC774\uC0C1)
 spring.codec.max-in-memory-size=10MB


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #49

---

## 🛠️ 작업 내용 (What)
- 공용 파일 업로드 서비스 로직 개선 (file 패키지)
- 정산(Expense) 저장 시 이미지 파일이 함께 저장되도록 로직 수정

- 바우처(Voucher) 도메인 추가
  - ERD 설계
  - 생성/조회/수정/삭제 API 구현

- 공지사항(Notices) 도메인 추가
  - ERD 설계
  - 생성/조회/수정/삭제 API 구현

- 여행 생성 시 기본 공지사항 자동 생성 로직 추가
  - 공지사항 그룹 1개 생성
  - 기본 공지사항 4개 자동 생성
    - 여행 준비물 체크리스트
    - 비상 연락처
    - 일정 및 예약 유의사항
    - 안전 주의사항

---

## 🧭 작업 목적 (Why)
- 파일 업로드 로직을 공통 서비스로 정리하여 재사용성과 유지보수성 향상
- 정산 데이터 저장 시 이미지까지 함께 저장되도록 하여 실제 서비스 흐름 완성
- 바우처 및 공지사항 기능을 위한 백엔드 도메인 및 API 구조 구축
- 여행 생성 직후 기본 공지사항이 자동 생성되도록 하여 사용자 편의성 개선

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [x] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 정산 생성 시 이미지 업로드 및 저장 확인
- [x] 바우처 CRUD API 동작 확인
- [x] 공지사항 CRUD API 동작 확인
- [x] 여행 생성 시 기본 공지사항 자동 생성 확인
- [x] 예외 케이스 확인 (존재하지 않는 데이터, 권한 등)

---

## ⚠️ 참고 사항
- 파일 업로드 로직이 공통 서비스로 변경되면서 기존 파일 처리 흐름에 영향이 있습니다.
- 정산(Expense) 저장 API에 이미지 파일 처리 로직이 추가되었습니다.
- 바우처 및 공지사항 도메인이 신규 추가되어 DB 스키마 변경이 포함됩니다.
- 여행 생성 시 공지사항이 자동 생성되도록 로직이 추가되었습니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료