### PR TITLE
[BE] refactor: ApplicationResponse DTO에 profileImage 및 travelStyles 필…

### DIFF
--- a/src/main/java/com/tripmoa/community/mate/dto/ApplicationResponse.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/ApplicationResponse.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 @Getter
@@ -38,7 +39,10 @@ public class ApplicationResponse {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
+    private String profileImage;
     private String avatar;
+
+    private List<String> travelStyles;
     private int age;
     private String gender;
 
@@ -67,7 +71,13 @@ public class ApplicationResponse {
                 .endDate(post.getEndDate())
                 .status(application.getStatus())
                 .content(application.getContent())
+                .profileImage(applicant.getProfileImage())
                 .avatar(applicant.getAvatarEmoji())
+                .travelStyles(
+                        application.getApplicant().getTravelStyles().stream()
+                        .map(userStyle -> userStyle.getStyle().getName())
+                        .toList()
+                )
                 .age(age)
                 .gender(genderName)
                 .build();


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #53

---
## 🛠️ 작업 내용 (What)
- `ApplicationResponse` DTO에 `profileImage: String` 필드 추가
- `ApplicationResponse` DTO에 `travelStyles: List<String>` 필드 추가
- DTO 생성 로직에서 `applicant.getProfileImage()` 매핑 추가
- DTO 생성 로직에서 `applicant.getTravelStyles()` → `style.getName()` 스트림 변환 후 매핑 추가

---
## 🧭 작업 목적 (Why)
프론트엔드에서 신청자 목록/상세 뷰 렌더링 시 `profileImage`와 `travelStyles`가 응답에 포함되지 않아 항상 `null`로 내려오는 문제 발생
`User` 엔티티에 해당 데이터가 존재함에도 DTO 매핑이 누락되어 있어 프론트와의 데이터가 일치하지 않는 상태였고, 이를 수정함

---
## 🧩 변경 범위
- [ ] Controller
- [x] Service
- [ ] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [ ] DB 스키마

---
## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
  - `GET /api/mate/applications/received` 응답에 `profileImage`, `travelStyles` 포함 여부 확인
  - 소셜 로그인 유저의 경우 `profileImage`에 실제 URL 반환 확인
  - 여행 스타일 미설정 유저의 경우 `travelStyles`가 빈 배열(`[]`)로 반환 확인
- [x] 예외 케이스 확인
  - `profileImage`가 `null`인 유저 정상 응답 확인
  - `travelStyles`가 없는 유저 NPE 없이 빈 배열 반환 확인

---
## ⚠️ 참고 사항
- 응답 필드 추가만 이루어지며 기존 필드 변경 없음 — 하위 호환성 유지
- `travelStyles`는 `UserStyle` 엔티티의 `style.getName()`을 통해 문자열 리스트로 변환하여 반환
- 프론트 이슈 #53 과 함께 배포 필요

---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] refactor/mateSent브랜치에서 작업
- [ ] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료