### PR TITLE
[BE] feature: 메이트 게시판 탭 지원 및 좋아요 상태 일관성 개선

### DIFF
--- a/src/main/java/com/tripmoa/community/mate/controller/MateController.java
+++ b/src/main/java/com/tripmoa/community/mate/controller/MateController.java
@@ -1,19 +1,25 @@
 package com.tripmoa.community.mate.controller;
 
+import com.tripmoa.community.mate.domain.MatePost;
 import com.tripmoa.community.mate.dto.*;
 import com.tripmoa.community.mate.service.MateApplicationService;
 import com.tripmoa.community.mate.service.MateLikeService;
 import com.tripmoa.community.mate.service.MateService;
+import com.tripmoa.community.mate.service.PassedPostService;
 import com.tripmoa.security.principal.CustomUserDetails;
 import com.tripmoa.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 //import org.springframework.security.access.prepost.PreAuthorize;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,11 +28,15 @@ public class MateController {
     private final MateService mateService;
     private final MateApplicationService applyService;
     private final MateLikeService likeService;
+    private final PassedPostService passedPostService;
 
     // 전체 메이트 포스트 조회
     @GetMapping("/")
-    public ResponseEntity<List<MateResponse>> getMatePosts() {
-        List<MateResponse> matePosts = this.mateService.getMatePosts();
+    public ResponseEntity<List<MateResponse>> getMatePosts(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUser().getId();
+        List<MateResponse> matePosts = this.mateService.getMatePosts(userId);
         return ResponseEntity.ok().body(matePosts);
     }
 
@@ -136,6 +146,33 @@ public class MateController {
         Long userId = userDetails.getUser().getId();
         LikeResponse response = likeService.toggleLike(postId, userId);
         return ResponseEntity.ok().body(response);
+    }
+
+    // passed 게시글
+    @PostMapping("/posts/{postId}/pass")
+    public ResponseEntity<Void> pass(@PathVariable Long postId,
+                                     @AuthenticationPrincipal CustomUserDetails user) {
+        passedPostService.pass(user.getUser().getId(), postId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/posts/{postId}/pass")
+    public ResponseEntity<Void> unpass(@PathVariable Long postId,
+                                       @AuthenticationPrincipal CustomUserDetails user) {
+        passedPostService.unpass(user.getUser().getId(), postId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/posts/passed")
+    public ResponseEntity<List<MateResponse>> getPassed(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        return ResponseEntity.ok(mateService.getPassedPosts(user.getUser().getId()));
+    }
+
+    @GetMapping("/posts/expired")
+    public ResponseEntity<List<MateResponse>> getExpired(Pageable pageable) {
+        return ResponseEntity.ok(mateService.getExpiredPosts(pageable));
     }
 
 }

--- a/src/main/java/com/tripmoa/community/mate/dto/MateResponse.java
+++ b/src/main/java/com/tripmoa/community/mate/dto/MateResponse.java
@@ -1,5 +1,6 @@
 package com.tripmoa.community.mate.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tripmoa.community.mate.enums.AgeGroup;
 import com.tripmoa.community.mate.enums.GenderPreference;
 import com.tripmoa.community.mate.domain.MatePost;

--- a/src/main/java/com/tripmoa/community/mate/repository/MateRepository.java
+++ b/src/main/java/com/tripmoa/community/mate/repository/MateRepository.java
@@ -1,12 +1,15 @@
 package com.tripmoa.community.mate.repository;
 
 import com.tripmoa.community.mate.domain.MatePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,4 +28,6 @@ public interface MateRepository extends JpaRepository <MatePost, Long>, LikeRepo
     @Modifying
     @Query("UPDATE MatePost m SET m.viewsCount = m.viewsCount + 1 WHERE m.id = :postId")
     void updateViewsCount(@Param("postId") Long postId);
+
+    Page<MatePost> findByEndDateBeforeOrderByEndDateDesc(LocalDate date, Pageable pageable);
 }

--- a/src/main/java/com/tripmoa/community/mate/service/MateLikeService.java
+++ b/src/main/java/com/tripmoa/community/mate/service/MateLikeService.java
@@ -57,4 +57,14 @@ public class MateLikeService {
             return 0L;
         }
     }
+
+    public boolean isLikedByUser(Long postId, Long userId) {
+        if (userId == null) return false;
+
+        String likeUserKey = "post:" + postId + ":likeUsers";
+        return Boolean.TRUE.equals(
+                redisTemplate.boundSetOps(likeUserKey)
+                        .isMember(String.valueOf(userId))
+        );
+    }
 }

--- a/src/main/java/com/tripmoa/community/mate/service/MateService.java
+++ b/src/main/java/com/tripmoa/community/mate/service/MateService.java
@@ -11,12 +11,16 @@ import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.user.entity.User;
 import com.tripmoa.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,16 +30,18 @@ public class MateService {
     private final UserRepository userRepository;
     private final ApplicationRepository applyRepository;
     private final MateLikeService likeService;
+    private final PassedPostService passedPostService;
     private final MateDomain domain;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public List<MateResponse> getMatePosts() {
+    public List<MateResponse> getMatePosts(Long userId) {
         List<MatePost> matePosts = mateRepository.findAllWithUser();
         return matePosts.stream()
                 .map(post -> {
                     MateResponse response = MateResponse.from(post);
-                    Long likeCount = likeService.getLikeCount(post.getId());
-                    response.setLikesCount(likeCount);
+                    response.setLikesCount(likeService.getLikeCount(post.getId()));
+                    response.setLiked(likeService.isLikedByUser(post.getId(), userId));
+
                     return response;
                 })
                 .collect(Collectors.toList());
@@ -45,6 +51,7 @@ public class MateService {
     public MateResponse getPostsById(Long id, Long userId) {
         MatePost matePostDetail = mateRepository.findByIdWithUser(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
+
         String redisKey = "view:mate:" + id + ":user:" + userId;
         Boolean isFirstView = redisTemplate
                 .opsForValue()
@@ -54,20 +61,10 @@ public class MateService {
             mateRepository.updateViewsCount(id);
         }
 
-        Long likeCount = likeService.getLikeCount(id);
-        boolean isLiked = false;
-        String likeUserKey = "post:" + id + ":likeUsers";
-        isLiked = Boolean.TRUE.equals(
-                redisTemplate
-                        .boundSetOps(likeUserKey)
-                        .isMember(String.valueOf(userId)));
-
         MateResponse response = MateResponse.from(matePostDetail);
-        response.setLikesCount(likeCount);
-        response.setLiked(isLiked);
-
-        boolean hasApplied = applyRepository.existsByMatePostIdAndApplicantId(id, userId);
-        response.setHasApplied(hasApplied);
+        response.setLikesCount(likeService.getLikeCount(id));
+        response.setLiked(likeService.isLikedByUser(id, userId));
+        response.setHasApplied(applyRepository.existsByMatePostIdAndApplicantId(id, userId));
 
         return response;
     }
@@ -89,6 +86,24 @@ public class MateService {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_POST_ACCESS);
         }
         mateRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MateResponse> getExpiredPosts(Pageable pageable) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        return mateRepository
+                .findByEndDateBeforeOrderByEndDateDesc(today, pageable)
+                .map(MateResponse::from)
+                .getContent();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MateResponse> getPassedPosts(Long userId) {
+        Set<Long> ids = passedPostService.getPassedIds(userId);
+        if (ids.isEmpty()) return List.of();
+        return mateRepository.findAllById(ids).stream()
+                .map(MateResponse::from)
+                .toList();
     }
 
 

--- a/src/main/java/com/tripmoa/community/mate/service/PassedPostService.java
+++ b/src/main/java/com/tripmoa/community/mate/service/PassedPostService.java
@@ -1,0 +1,38 @@
+package com.tripmoa.community.mate.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PassedPostService {
+    private final StringRedisTemplate redis;
+    private static final long TTL_MS = 24 * 60 * 60 * 1000L;
+
+    private String key(Long userId) { return "mate:passed:" + userId; }
+
+    public void pass(Long userId, Long postId) {
+        long now = System.currentTimeMillis();
+        String k = key(userId);
+        redis.opsForZSet().add(k, postId.toString(), now);
+        redis.opsForZSet().removeRangeByScore(k, 0, now - TTL_MS);
+    }
+
+    public void unpass(Long userId, Long postId) {
+        redis.opsForZSet().remove(key(userId), postId.toString());
+    }
+
+    public Set<Long> getPassedIds(Long userId) {
+        long now = System.currentTimeMillis();
+        String k = key(userId);
+        redis.opsForZSet().removeRangeByScore(k, 0, now - TTL_MS);
+        Set<String> ids = redis.opsForZSet().rangeByScore(k, now - TTL_MS, now);
+        return ids == null ? Set.of()
+                : ids.stream().map(Long::parseLong).collect(Collectors.toSet());
+    }
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #57

---
## 🛠️ 작업 내용 (What)

### ✨ 신규 API
- `POST /api/mate/posts/{postId}/pass` — PASS 등록 (Redis ZSet, 24h TTL)
- `DELETE /api/mate/posts/{postId}/pass` — PASS 해제
- `GET /api/mate/posts/passed` — 내 PASSED 목록 조회
- `GET /api/mate/posts/expired` — 만료 게시글 조회 (`endDate < today` 기준)

### 🐛 버그 수정
- `MateService.getMatePosts()`에서 좋아요 상태(`liked`) 판정 누락 수정
  - 원인: 목록 조회 시 `userId`를 받지 않아 Redis 기반 `liked` 판정이 불가능했음
  - 수정: 메서드 시그니처에 `userId` 추가, `MateLikeService.isLikedByUser()` 호출
- Controller에서 `@AuthenticationPrincipal`로 userId 전달 보장

### 🧹 리팩터링
- `MateLikeService.isLikedByUser(postId, userId)` 메서드 추출
  - 기존: `MateService`에서 `redisTemplate` 직접 호출하여 중복 코드 발생
  - 변경: 좋아요 관련 Redis 로직을 `MateLikeService`로 일원화
- `MateService.getPostsById()` 내 Redis 직접 접근 코드를 `MateLikeService` 위임으로 교체

---
## 🧭 작업 목적 (Why)

**PASSED/EXPIRED 탭 지원:**
기존에 프론트 localStorage로 관리되던 PASS 상태를 서버(Redis)로 이전하여
기기 간 일관성을 확보하고, 만료 게시글을 별도 탭으로 조회 가능하게 함

**좋아요 상태 동기화:**
`toggleLike`는 Redis에 저장하지만 `getMatePosts`는 DB 기반으로 판정하여
새로고침 시 항상 `liked: false`로 응답하던 근본 원인을 해결

---
## 🧩 변경 범위
- [x] Controller
- [x] Service
- [ ] Domain(Entity)
- [ ] Repository
- [x] API 설계
- [ ] DB 스키마

---
## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

### 테스트 시나리오
1. **PASS 등록/해제**: `POST/DELETE /posts/{id}/pass` 후 `GET /posts/passed` 반영 확인
2. **PASS TTL**: Redis CLI에서 `ZSCORE mate:passed:{userId} {postId}` 확인, 24h 후 조회 제외
3. **EXPIRED 조회**: endDate가 오늘 이전인 게시글만 반환되는지 확인
4. **좋아요 상태**: 좋아요 토글 → `GET /mate/` 재호출 → `liked: true` 유지 확인
5. **비인증 요청**: 토큰 없이 `/posts/passed` 호출 시 401 반환

---
## ⚠️ 참고 사항
- **Redis 키 구조 추가**
  - `mate:passed:{userId}` (ZSet, score=timestamp, member=postId)
  - 기존 `post:{postId}:likeUsers` (Set)에서 조회하는 `isLikedByUser` 메서드 추가
- `MateService`에서 `RedisTemplate` 직접 의존은 조회수(`view:mate:...`) 때문에 유지
  - 후속 PR에서 `ViewCountService`로 분리 예정
- `LikeSyncScheduler`는 기존대로 count만 5분 주기 DB sync
  - `likeUsers` Set의 DB write-back은 별도 이슈로 관리
- **배포 순서: 백엔드 먼저 → 프론트** (새 엔드포인트 호출 시 404 방지)

---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료