### PR TITLE
[BE] feature: 만료된 게시글 신청 차단 예외 처리 및 검증 추가

### DIFF
--- a/src/main/java/com/tripmoa/community/mate/service/MateApplicationService.java
+++ b/src/main/java/com/tripmoa/community/mate/service/MateApplicationService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -47,6 +48,10 @@ public class MateApplicationService {
     public ApplicationResponse createApply(Long postId, ApplicationRequest request, User applicant) {
         MatePost post = this.mateRepository.findById(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
+
+        if(post.getEndDate().isBefore(LocalDate.now())) {
+            throw new BusinessException(ErrorCode.MATE_POST_EXPIRED);
+        }
 
         MateApplication application = MateApplication.builder()
                 .matePost(post)

--- a/src/main/java/com/tripmoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/tripmoa/global/exception/ErrorCode.java
@@ -123,6 +123,7 @@ public enum ErrorCode {
     CANNOT_APPLY_OWN_POST(HttpStatus.BAD_REQUEST, "MATE_400_012", "본인 게시글에는 신청할 수 없습니다"),
     ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "MATE_400_013", "이미 처리된 신청서입니다"),
     UNAUTHORIZED_APPLICATION_ACCESS(HttpStatus.FORBIDDEN, "MATE_403_002", "신청서 접근 권한이 없습니다"),
+    MATE_POST_EXPIRED(HttpStatus.BAD_REQUEST, "MATE_400_014", "만료된 게시글에는 신청 할 수 없습니다."),
 
     // ====== 서버 내부 오류 ======
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #59
- Closes #61 
---
## 🛠️ 작업 내용 (What)
- ErrorCode에 MATE_POST_EXPIRED(400, "만료된 게시글에는 신청할 수 없습니다") 추가
- MateApplicationService에서 신청 시 endDate < today 검증 로직 추가
- 만료된 게시글에 신청 요청 시 BusinessException 반환

---
## 🧭 작업 목적 (Why)
만료된 게시글(endDate가 지난 게시글)에 신청이 가능하여
불필요한 신청 데이터가 생성되는 문제 차단.

---
## 🧩 변경 범위
- [ ] Controller
- [x] Service
- [ ] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [ ] DB 스키마

---
## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인
- [ ] 만료된 게시글에 POST /api/mate/applications 요청 시 400 응답 확인
- [ ] 만료되지 않은 게시글에는 정상 신청 확인

---
## ⚠️ 참고 사항
- 게시글 상태(날짜) 기반 검증
- ErrorCode에 추가만 했고 별도 예외 클래스는 생성하지 않음 (단일 케이스이므로 BusinessException 직접 사용)

---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료