### PR TITLE
[BE] feature: 만료 게시글 신청 내역 삭제 API 추가

### DIFF
--- a/src/main/java/com/tripmoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/tripmoa/global/exception/ErrorCode.java
@@ -123,7 +123,8 @@ public enum ErrorCode {
     CANNOT_APPLY_OWN_POST(HttpStatus.BAD_REQUEST, "MATE_400_012", "본인 게시글에는 신청할 수 없습니다"),
     ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "MATE_400_013", "이미 처리된 신청서입니다"),
     UNAUTHORIZED_APPLICATION_ACCESS(HttpStatus.FORBIDDEN, "MATE_403_002", "신청서 접근 권한이 없습니다"),
-    MATE_POST_EXPIRED(HttpStatus.BAD_REQUEST, "MATE_400_014", "만료된 게시글에는 신청 할 수 없습니다."),
+    MATE_POST_EXPIRED(HttpStatus.BAD_REQUEST, "MATE_400_014", "만료된 게시글에는 신청 할 수 없습니다"),
+    MATE_POST_NOT_EXPIRED(HttpStatus.BAD_REQUEST, "MATE_400_015", "만료된 게시글의 신청서만 삭제할 수 있습니다"),
 
     // ====== 서버 내부 오류 ======
 

--- a/src/main/java/com/tripmoa/mate/controller/MateApplicationController.java
+++ b/src/main/java/com/tripmoa/mate/controller/MateApplicationController.java
@@ -76,4 +76,14 @@ public class MateApplicationController {
         ApplicationResponse rejectApply = this.applyService.rejectApply(applyId, author);
         return ResponseEntity.ok().body(rejectApply);
     }
+
+    @DeleteMapping("/applications/{applyId}/sent")
+    public ResponseEntity<Void> deleteApplication(
+            @PathVariable Long applyId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User applicant = userDetails.getUser();
+        this.applyService.deleteSentApplication(applyId, applicant);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/tripmoa/mate/controller/MateApplicationController.java
+++ b/src/main/java/com/tripmoa/mate/controller/MateApplicationController.java
@@ -86,4 +86,14 @@ public class MateApplicationController {
         this.applyService.deleteSentApplication(applyId, applicant);
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping("/applications/{applyId}/received")
+    public ResponseEntity<Void> deleteReceivedApplication(
+            @PathVariable Long applyId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User author = userDetails.getUser();
+        this.applyService.deleteReceivedApplication(applyId, author);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/tripmoa/mate/domain/MatePost.java
+++ b/src/main/java/com/tripmoa/mate/domain/MatePost.java
@@ -10,6 +10,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Getter
 @Builder
@@ -90,4 +91,7 @@ public class MatePost {
     public void incCurrentParticipant() {this.currentParticipant++;}
     public void decCurrentParticipant() {this.currentParticipant--;}
 
+    public boolean isExpired() {
+        return this.endDate.isBefore(LocalDate.now(ZoneId.of("Asia/Seoul")));
+    }
 }

--- a/src/main/java/com/tripmoa/mate/service/MateApplicationService.java
+++ b/src/main/java/com/tripmoa/mate/service/MateApplicationService.java
@@ -95,4 +95,15 @@ public class MateApplicationService {
         return applyRepository.existsByMatePostIdAndApplicantId(postId, userId);
     }
 
+    private MateApplication findAndValidateExpired(Long applyId) {
+        MateApplication application = applyRepository.findById(applyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLICATION_NOT_FOUND));
+
+        if (!application.getMatePost().isExpired()) {
+            throw new BusinessException(ErrorCode.MATE_POST_NOT_EXPIRED);
+        }
+
+        return application;
+    }
+
 }

--- a/src/main/java/com/tripmoa/mate/service/MateApplicationService.java
+++ b/src/main/java/com/tripmoa/mate/service/MateApplicationService.java
@@ -116,4 +116,14 @@ public class MateApplicationService {
 
         applyRepository.delete(application);
     }
+
+    public void deleteReceivedApplication(Long applyId, User author) {
+        MateApplication application = findAndValidateExpired(applyId);
+
+        if(!application.isAuthor(author)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_APPLICATION_ACCESS);
+        }
+
+        applyRepository.delete(application);
+    }
 }

--- a/src/main/java/com/tripmoa/mate/service/MateApplicationService.java
+++ b/src/main/java/com/tripmoa/mate/service/MateApplicationService.java
@@ -106,4 +106,14 @@ public class MateApplicationService {
         return application;
     }
 
+    @Transactional
+    public void deleteSentApplication(Long applyId, User applicant) {
+        MateApplication application = findAndValidateExpired(applyId);
+
+        if(!application.getApplicant().getId().equals(applicant.getId())) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_APPLICATION_ACCESS);
+        }
+
+        applyRepository.delete(application);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #64

---
## 🛠️ 작업 내용 (What)
- `ErrorCode`에 `MATE_POST_NOT_EXPIRED` 추가
- `DELETE /api/mate/applications/{id}/sent` 엔드포인트 추가 (신청자 본인 삭제)
- `DELETE /api/mate/applications/{id}/received` 엔드포인트 추가 (게시글 작성자 삭제)
- `MateApplicationService`에 `deleteSentApplication()`, `deleteReceivedApplication()`, `findAndValidateExpired()` 추가

---
## 🧭 작업 목적 (Why)
만료된 게시글에 남아있는 신청 내역을 신청자/작성자가 직접 정리할 수 있도록 삭제 API 제공.
만료되지 않은 게시글의 신청은 삭제할 수 없도록 검증 포함.

---
## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [ ] DB 스키마

---
## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

### 테스트 시나리오
- 만료된 게시글 신청 → `/sent` 삭제 → 204 확인
- 만료된 게시글 신청 → `/received` 삭제 → 204 확인
- 만료되지 않은 게시글 삭제 시도 → 400 (MATE_POST_NOT_EXPIRED)
- 권한 없는 사용자 삭제 시도 → 403 (UNAUTHORIZED_APPLICATION_ACCESS)
- 존재하지 않는 신청 삭제 시도 → 404 (APPLICATION_NOT_FOUND)

---
## ⚠️ 참고 사항
- hard delete 방식 (DB에서 완전 삭제)
- 승인된 신청도 만료 후에는 삭제 가능하며, 기존 채팅방은 유지됨

---
## ✅ 체크리스트
- [ ] main 브랜치 직접 push 하지 않음
- [ ] feature/refactor/bugfix 브랜치에서 작업
- [ ] 불필요한 로그 제거
- [ ] API 명세 변경 시 공유 완료