### PR TITLE
[BE] refactor: 채팅 response DTO senderId를 email에서 userId로 변경

### DIFF
--- a/src/main/java/com/tripmoa/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/tripmoa/chat/dto/ChatMessageResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class ChatMessageResponse {
 
     private String id;
-    private String senderId;
+    private Long senderId;
     private String senderName;
     private String senderAvatar;
     private String content;
@@ -19,7 +19,7 @@ public class ChatMessageResponse {
     public static ChatMessageResponse from(ChatMessage message) {
         return ChatMessageResponse.builder()
                 .id(String.valueOf(message.getId()))
-                .senderId(message.getSender().getEmail())
+                .senderId(message.getSender().getId())
                 .senderName(message.getSender().getName())
                 .senderAvatar(message.getSender().getProfileImage())
                 .content(message.getContent())

--- a/src/main/java/com/tripmoa/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/tripmoa/chat/dto/ChatRoomResponse.java
@@ -12,8 +12,8 @@ public class ChatRoomResponse {
 
     private String id;                  // chatRoom ID
     private String postId;              // 게시글 ID
-    private String postAuthorId;        // 게시글 작성자 이메일
-    private String applicantId;         // 신청자 이메일
+    private Long postAuthorId;        // 게시글 작성자 ID
+    private Long applicantId;         // 신청자 ID
     private String destination;         // 여행지
     private String startDate;           // 여행 시작일
     private String endDate;             // 여행 종료일
@@ -39,8 +39,8 @@ public class ChatRoomResponse {
         return ChatRoomResponse.builder()
                 .id(String.valueOf(room.getId()))
                 .postId(String.valueOf(room.getMatePost().getId()))
-                .postAuthorId(room.getAuthor().getEmail())
-                .applicantId(room.getApplicant().getEmail())
+                .postAuthorId(room.getAuthor().getId())
+                .applicantId(room.getApplicant().getId())
                 .destination(room.getMatePost().getDestination())
                 .startDate(room.getMatePost().getStartDate().toString())
                 .endDate(room.getMatePost().getEndDate().toString())


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #85 
---
## 🛠️ 작업 내용 (What)
- `ChatMessageResponse.senderId`를 `getSender().getEmail()` → `getSender().getId()`로 변경 (String → Long)
- `ChatRoomResponse.postAuthorId`를 `getPostAuthor().getEmail()` → `getPostAuthor().getId()`로 변경 (String → Long)
- `ChatRoomResponse.applicantId`를 `getApplicant().getEmail()` → `getApplicant().getId()`로 변경 (String → Long)
---
## 🧭 작업 목적 (Why)
- FE 인증 체계가 `useAuth().userId`(숫자 ID) 기반으로 통일됨에 따라 BE 응답도 일치시킴
- email 기반 비교로 인해 채팅 메시지 좌/우 정렬이 깨지는 버그의 근본 원인 해결
- 채팅 API 응답에서 사용자 email 노출 최소화
---
## 🧩 변경 범위
- [ ] Controller
- [ ] Service
- [ ] Domain(Entity)
- [ ] Repository
- [x] API 설계
- [ ] DB 스키마

### API 응답 변경
| 필드 | Before | After |
|------|--------|-------|
| `ChatMessageResponse.senderId` | `String` (email) | `Long` (userId) |
| `ChatRoomResponse.postAuthorId` | `String` (email) | `Long` (userId) |
| `ChatRoomResponse.applicantId` | `String` (email) | `Long` (userId) |
---
## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인
- `GET /api/chat/rooms` → 응답의 `postAuthorId`, `applicantId`가 숫자 ID인지 확인
- `GET /api/chat/rooms/{id}` → 메시지 내 `senderId`가 숫자 ID인지 확인
- STOMP 실시간 메시지 수신 시 `senderId` 타입 확인
---
## ⚠️ 참고 사항
- FE PR(채팅 컴포넌트 email→userId 전환)과 함께 머지해야 정상 동작합니다
- STOMP으로 전송되는 메시지도 동일한 DTO를 사용하므로 별도 수정 불필요
---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료