### PR TITLE
[BE] feature: 신고하기 API 구현

### DIFF
--- a/src/main/java/com/tripmoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/tripmoa/global/exception/ErrorCode.java
@@ -159,6 +159,11 @@ public enum ErrorCode {
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "STORY_400_002", "유효하지 않은 이미지 파일입니다."),
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "STORY_500_001", "이미지 업로드 중 오류가 발생했습니다."),
 
+    // ====== Report 도메인 ======
+    CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST, "REPORT_400_001", "자기 자신은 신고할 수 없습니다."),
+    ALREADY_REPORTED(HttpStatus.CONFLICT, "REPORT_409_001", "이미 신고한 대상입니다."),
+    REPORTED_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_404_001", "신고 대상 사용자를 찾을 수 없습니다."),
+
     // ====== 서버 내부 오류 ======
 
     // 예기치 못한 서버 에러 (GlobalExceptionHandler fallback)

--- a/src/main/java/com/tripmoa/report/ReportController.java
+++ b/src/main/java/com/tripmoa/report/ReportController.java
@@ -1,0 +1,28 @@
+package com.tripmoa.report;
+
+import com.tripmoa.security.principal.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<Void> report(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ReportRequest request) {
+
+        reportService.report(userDetails.getUser().getId(), request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/tripmoa/report/ReportLocation.java
+++ b/src/main/java/com/tripmoa/report/ReportLocation.java
@@ -3,6 +3,6 @@ package com.tripmoa.report;
 // 신고 위치
 public enum ReportLocation {
 
-    COMMENT, CHAT, POST
+    COMMENT, CHAT, POST, MATE
 
 }

--- a/src/main/java/com/tripmoa/report/ReportRepository.java
+++ b/src/main/java/com/tripmoa/report/ReportRepository.java
@@ -1,0 +1,9 @@
+package com.tripmoa.report;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<UserReport, Long> {
+
+    // 같은 사람이 같은 대상을 이미 신고했는지 (중복 신고 방지)
+    boolean existsByReporterIdAndLocationAndTargetId(Long reporterId, ReportLocation location, Long targetId);
+}

--- a/src/main/java/com/tripmoa/report/ReportRequest.java
+++ b/src/main/java/com/tripmoa/report/ReportRequest.java
@@ -1,0 +1,27 @@
+package com.tripmoa.report;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReportRequest {
+
+    @NotNull(message = "신고 대상 유저 ID는 필수입니다")
+    private Long reportedUserId;
+
+    @NotNull(message = "신고 위치는 필수입니다")
+    private ReportLocation location;
+
+    @NotNull(message = "대상 ID는 필수입니다")
+    private Long targetId;
+
+    @NotBlank(message = "신고 사유는 필수입니다")
+    private String reason;
+
+    private String detail;
+    private String contentSnapshot;
+    private String reportedNickname;
+}

--- a/src/main/java/com/tripmoa/report/ReportService.java
+++ b/src/main/java/com/tripmoa/report/ReportService.java
@@ -1,0 +1,60 @@
+package com.tripmoa.report;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private static final int SNAPSHOT_MAX_LENGTH = 200;
+
+    @Transactional
+    public void report(Long reporterId, ReportRequest request) {
+        // 자기 자신 신고 방지
+        if (reporterId.equals(request.getReportedUserId())) {
+            throw new BusinessException(ErrorCode.CANNOT_REPORT_SELF);
+        }
+
+        // 중복 신고 방지
+        boolean alreadyReported = reportRepository
+                .existsByReporterIdAndLocationAndTargetId(reporterId, request.getLocation(), request.getTargetId());
+
+        if (alreadyReported) {
+            throw new BusinessException(ErrorCode.ALREADY_REPORTED);
+        }
+
+        User reporter = userRepository.findById(reporterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        User reportedUser = userRepository.findById(request.getReportedUserId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.REPORTED_USER_NOT_FOUND));
+
+        UserReport report = UserReport.builder()
+                .reporter(reporter)
+                .reportedUser(reportedUser)
+                .reportedNickname(request.getReportedNickname())
+                .location(request.getLocation())
+                .targetId(request.getTargetId())
+                .reason(request.getReason())
+                .detail(request.getDetail())
+                .contentSnapshot(truncate(request.getContentSnapshot()))
+                .build();
+
+        reportRepository.save(report);
+    }
+
+    private String truncate(String text) {
+        if (text == null) return null;
+        if (text.length() <= SNAPSHOT_MAX_LENGTH) return text;
+        return text.substring(0, SNAPSHOT_MAX_LENGTH) + "...";
+    }
+}
+

--- a/src/main/java/com/tripmoa/report/UserReport.java
+++ b/src/main/java/com/tripmoa/report/UserReport.java
@@ -2,30 +2,73 @@ package com.tripmoa.report;
 
 import com.tripmoa.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user_reports")
 @Getter
-@Setter
+@NoArgsConstructor
 public class UserReport {
-    
-    // 신고 이력
 
     @Id
-    @GeneratedValue(strategy = GenerationType .IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+    // 신고한 사람
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
 
+    // 신고당한 사람
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private User reportedUser;
+
+    // 신고당한 사람 닉네임 (탈퇴 대비)
+    @Column(length = 50)
+    private String reportedNickname;
+
+    // 신고 위치 (POST, COMMENT, CHAT, MATE)
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ReportLocation location;
 
+    // 대상 ID (chatRoomId, postId, commentId)
+    @Column(nullable = false)
+    private Long targetId;
+
+    // 신고 사유 (라디오 선택값)
+    @Column(nullable = false)
     private String reason;
-    private LocalDate reportedAt;
+
+    // 추가 설명 (선택)
+    @Column(length = 500)
+    private String detail;
+
+    @Column(nullable = false)
+    private LocalDateTime reportedAt;
+
+    // 스냅샷 방식
+    @Column(length = 1000)
+    private String contentSnapshot;
+
+    @Builder
+    public UserReport(User reporter, User reportedUser, String reportedNickname,
+                      ReportLocation location,
+                      Long targetId, String reason, String detail,
+                      String contentSnapshot) {
+        this.reporter = reporter;
+        this.reportedUser = reportedUser;
+        this.reportedNickname = reportedNickname;
+        this.location = location;
+        this.targetId = targetId;
+        this.reason = reason;
+        this.detail = detail;
+        this.contentSnapshot = contentSnapshot;
+        this.reportedAt = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #87 

---

## 🛠️ 작업 내용 (What)

- `UserReport` 엔티티 및 `ReportLocation` enum 정의
- `ReportController` → `ReportService` → `reportRepository` API 계층 구현
- `ReportRequest` DTO (validation 포함)
- 신고 관련 커스텀 에러코드 추가 (`CANNOT_REPORT_SELF`, `ALREADY_REPORTED`, `REPORTED_USER_NOT_FOUND`)
- 스냅샷 200자 초과 시 truncate 처리

---

## 🧭 작업 목적 (Why)

게시글, 댓글, 채팅에서 부적절한 사용자를 신고할 수 있는 API가 필요
신고 대상이 원본 콘텐츠를 삭제하더라도 관리자가 신고 내역을 확인할 수 있도록 스냅샷 방식으로 증거를 보존

---

## 🧩 변경 범위
- [x] Controller — `ReportController` (`POST /api/reports`)
- [x] Service — `ReportService` (중복/자기자신 신고 방지, 스냅샷 truncate)
- [x] Domain(Entity) — `UserReport`, `ReportLocation`
- [x] Repository — `UserReportRepository` (중복 체크 쿼리)
- [x] API 설계 — `POST /api/reports` 신규
- [x] DB 스키마 — `user_reports` 테이블 수정

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인
  - 자기 자신 신고 → `400 CANNOT_REPORT_SELF`
  - 동일 대상 중복 신고 → `409 ALREADY_REPORTED`
  - 존재하지 않는 유저 신고 → `404 REPORTED_USER_NOT_FOUND`
  - 스냅샷 200자 초과 → 잘림 확인

---

## ⚠️ 참고 사항
- `UserReport.reporter`는 `@AuthenticationPrincipal CustomUserDetails`에서 추출
- `contentSnapshot`은 프론트에서 신고 시점의 콘텐츠를 전달받아 저장 (백엔드에서 200자 truncate)
- `reportedNickname`은 유저 탈퇴/닉네임 변경 대비용
- `location` 필드로 POST / COMMENT / CHAT / MATE 구분

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료