### PR TITLE
[BE] feature: Schedule(Day) 생성 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/tripmoa/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tripmoa/schedule/controller/ScheduleController.java
@@ -1,0 +1,84 @@
+package com.tripmoa.schedule.controller;
+
+import com.tripmoa.ai.dto.AiScheduleRequest;
+import com.tripmoa.schedule.dto.ScheduleGenerateRequest;
+import com.tripmoa.schedule.dto.ScheduleResponse;
+import com.tripmoa.schedule.service.ScheduleService;
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.trip.service.TripPermissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+//    private final TripPermissionService tripPermissionService;
+
+    //  일정 생성 (AI) POST /api/schedules/ai(Trip 오너 or 멤버만 가능)
+//    @PostMapping("/ai")
+//    public ResponseEntity<Void> generate(@AuthenticationPrincipal CustomUserDetails userDetails,
+//                                         @RequestBody ScheduleGenerateRequest request) {
+//
+//         Long userId = userDetails.getUser().getId();
+//         tripPermissionService.assertOwnerOrMember(request.getTripId(), userId);
+//
+//         // 프론트 요청을 그대로 Python으로 전달
+//        AiScheduleRequest airequest = AiScheduleRequest.builder()
+//                .places(request.getPlaces())
+//                .n_days(request.getN_days())
+//                .transportation_mode(request.getTransportation_mode())
+//                .start_date(request.getStart_date())
+//                .end_date(request.getEnd_date())
+//                .daily_start_time(request.getDaily_start_time())
+//                .daily_end_time(request.getDaily_end_time())
+//                .user_preferences(request.getUser_preferences())
+//                .pinned_places(request.getPinned_places())
+//                .hotels(request.getHotels())
+//                .departure_points(request.getDeparture_points())
+//                .build();
+//
+//        scheduleService.generateAndSave(request.getTripId(), airequest);
+//
+//        return ResponseEntity.ok().build();
+//    }
+    @PostMapping("/ai")
+    public ResponseEntity<List<ScheduleResponse>> generate(@RequestBody ScheduleGenerateRequest request) {
+        AiScheduleRequest airequest = AiScheduleRequest.builder()
+                .places(request.getPlaces())
+                .n_days(request.getN_days())
+                .transportation_mode(request.getTransportation_mode())
+                .start_date(request.getStart_date())
+                .end_date(request.getEnd_date())
+                .daily_start_time(request.getDaily_start_time())
+                .daily_end_time(request.getDaily_end_time())
+                .user_preferences(request.getUser_preferences())
+                .pinned_places(request.getPinned_places())
+                .hotels(request.getHotels())
+                .departure_points(request.getDeparture_points())
+                .build();
+
+        List<ScheduleResponse> result = scheduleService.generateAndSave(request.getTripId(), airequest);
+        return ResponseEntity.ok(result);
+    }
+    //    // 일정 조회 GET /api/schedules?tripId=1(Trip 오너 or 멤버만 가능))
+//    @GetMapping
+//    public ResponseEntity<List<ScheduleResponse>> getSchedules(@AuthenticationPrincipal CustomUserDetails userDetails,
+//                                                               @RequestParam Long tripId) {
+//        Long userId = userDetails.getUser().getId();
+//        tripPermissionService.assertOwnerOrMember(tripId, userId);
+//
+//        return ResponseEntity.ok(scheduleService.getSchedules(tripId));
+//    }
+    @GetMapping
+    public ResponseEntity<List<ScheduleResponse>> getSchedules(@RequestParam Long tripId) {
+        return ResponseEntity.ok(scheduleService.getSchedules(tripId));
+    }
+
+}

--- a/src/main/java/com/tripmoa/schedule/domain/Schedule.java
+++ b/src/main/java/com/tripmoa/schedule/domain/Schedule.java
@@ -1,0 +1,29 @@
+package com.tripmoa.schedule.domain;
+
+import com.tripmoa.trip.entity.Trip;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Schedule (Day 단위 일정)
+ *
+ * - 하나의 여행(trip)은 여러 개의 Day를 가짐
+ * - 예: Day1, Day2, Day3
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 여행에 속하는 일정인지
+    private Long tripId;
+
+    // 몇 번째 날인지 (1,2,3...)
+    private int day;
+}

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleGenerateRequest.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleGenerateRequest.java
@@ -1,0 +1,31 @@
+package com.tripmoa.schedule.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 일정 생성 요청 DTO
+ * - 프론트 → 백엔드
+ * - AI 서버로 넘길 데이터 포함
+ */
+@Getter
+public class ScheduleGenerateRequest {
+
+    private Long tripId;
+
+    // 장소 목록 (AI에 전달)
+    private List<Object> places;
+    private int n_days;
+
+    private String transportation_mode;
+    private String start_date;
+    private String end_date;
+    private String daily_start_time;
+    private String daily_end_time;
+
+    private Object user_preferences;
+    private List<Object> pinned_places;
+    private List<Object> hotels;
+    private List<Object> departure_points;
+}

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleResponse.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleResponse.java
@@ -1,0 +1,16 @@
+package com.tripmoa.schedule.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ScheduleResponse {
+
+    private Long scheduleId;  // 추가: 클라이언트에서 day 식별용
+    private int day;
+    private List<ScheduleItemResponse> items;
+
+}

--- a/src/main/java/com/tripmoa/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/tripmoa/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,17 @@
+package com.tripmoa.schedule.repository;
+
+import com.tripmoa.schedule.domain.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * ScheduleRepository
+ * - Day 단위 일정 조회
+ */
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    // 특정 여행 전체 일정 조회
+    List<Schedule> findAllByTripId(Long tripId);
+
+}

--- a/src/main/java/com/tripmoa/schedule/service/ScheduleAiService.java
+++ b/src/main/java/com/tripmoa/schedule/service/ScheduleAiService.java
@@ -1,0 +1,21 @@
+package com.tripmoa.schedule.service;
+
+import com.tripmoa.ai.domain.AiClient;
+import com.tripmoa.ai.dto.AiScheduleRequest;
+import com.tripmoa.ai.dto.AiScheduleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * AI 호출 담당
+ */
+@Service
+@RequiredArgsConstructor
+public class ScheduleAiService {
+
+    private final AiClient aiClient;
+
+    public AiScheduleResponse response(AiScheduleRequest request) {
+        return aiClient.generate(request);
+    }
+}

--- a/src/main/java/com/tripmoa/schedule/service/ScheduleMapper.java
+++ b/src/main/java/com/tripmoa/schedule/service/ScheduleMapper.java
@@ -1,0 +1,98 @@
+//package com.tripmoa.schedule.service;
+//
+//import com.tripmoa.ai.dto.AiScheduleResponse;
+//import com.tripmoa.schedule.domain.Schedule;
+//import com.tripmoa.schedule.domain.ScheduleItem;
+//
+//import java.util.ArrayList;
+//import java.util.List;
+//
+///**
+// * AI 응답 → DB Entity 변환
+// */
+//public class ScheduleMapper {
+//
+//    public static List<Schedule> toSchedules(Long tripId, AiScheduleResponse response){
+//
+//        List<Schedule> schedules = new ArrayList<>();
+//
+//        for(AiScheduleResponse.DayPlan day : response.getDays()) {
+//            schedules.add(
+//                    Schedule.builder()
+//                            .tripId(tripId)
+//                            .day(day.getDay())
+//                            .build()
+//            );
+//        }
+//        return schedules;
+//    }
+//
+//    public static List<ScheduleItem> toScheduleItems(Long scheduleId,
+//                                                     AiScheduleResponse.DayPlan dayPlan){
+//
+//        List<ScheduleItem> items = new ArrayList<>();
+//
+//        int index = 0;
+//        for(AiScheduleResponse.Item item : dayPlan.getItems()) {
+//            items.add(
+//                    ScheduleItem.builder()
+//                            .scheduleId(scheduleId)
+//                            .time(item.getTime())
+//                            .title(item.getTitle())
+//                            .description(item.getDescription())
+//                            .orderIndex(index++)
+//                            .build()
+//            );
+//        }
+//
+//        return items;
+//    }
+//}
+package com.tripmoa.schedule.service;
+
+import com.tripmoa.ai.dto.AiScheduleResponse;
+import com.tripmoa.schedule.domain.Schedule;
+import com.tripmoa.schedule.domain.ScheduleItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ScheduleMapper {
+
+    public static List<Schedule> toSchedules(Long tripId, AiScheduleResponse response) {
+        List<Schedule> schedules = new ArrayList<>();
+
+        // itinerary.days 리스트 순회
+        for (AiScheduleResponse.DayPlan day : response.getItinerary().getDays()) {
+            schedules.add(
+                    Schedule.builder()
+                            .tripId(tripId)
+                            .day(day.getDay())
+                            .build()
+            );
+        }
+        return schedules;
+    }
+
+    public static List<ScheduleItem> toScheduleItems(Long scheduleId,
+                                                     AiScheduleResponse.DayPlan dayPlan) {
+        List<ScheduleItem> items = new ArrayList<>();
+        int index = 0;
+
+        for (AiScheduleResponse.Item item : dayPlan.getPlaces()) {
+            items.add(
+                    ScheduleItem.builder()
+                            .scheduleId(scheduleId)
+                            .time(item.getTime() != null ? item.getTime() : "00:00")
+                            .title(item.getPlace() != null ? item.getPlace() : "")
+                            .category(item.getCategory() != null ? item.getCategory() : "")
+                            .description(item.getAddress() != null ? item.getAddress() : "")
+                            .lat(item.getLat())
+                            .lng(item.getLng())
+                            .orderIndex(index++)
+                            .build()
+            );
+        }
+        return items;
+    }
+}

--- a/src/main/java/com/tripmoa/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tripmoa/schedule/service/ScheduleService.java
@@ -1,0 +1,99 @@
+package com.tripmoa.schedule.service;
+
+import com.tripmoa.ai.dto.AiScheduleRequest;
+import com.tripmoa.ai.dto.AiScheduleResponse;
+import com.tripmoa.schedule.domain.Schedule;
+import com.tripmoa.schedule.domain.ScheduleItem;
+import com.tripmoa.schedule.dto.ScheduleItemResponse;
+import com.tripmoa.schedule.dto.ScheduleResponse;
+import com.tripmoa.schedule.repository.ScheduleItemRepository;
+import com.tripmoa.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * DB 저장 + 조회 담당
+ */
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final ScheduleAiService scheduleAiService;
+    private final ScheduleRepository scheduleRepository;
+    private final ScheduleItemRepository scheduleItemRepository;
+
+    /**
+     * AI 일정 생성 후 DB 저장
+     * - 기존 일정이 있으면 삭제 후 재생성 (중복 방지)
+     */
+    @Transactional
+    public List<ScheduleResponse> generateAndSave(Long tripId, AiScheduleRequest request) {
+
+        // 기존 일정 삭제 (재생성 케이스 대비)
+        List<Schedule> existing = scheduleRepository.findAllByTripId(tripId);
+        if (!existing.isEmpty()) {
+            List<Long> scheduleIds = existing.stream().map(Schedule::getId).toList();
+            scheduleIds.forEach(scheduleItemRepository::deleteAllByScheduleId);
+            scheduleRepository.deleteAll(existing);
+        }
+
+        // AI 호출
+        AiScheduleResponse response = scheduleAiService.response(request);
+
+        // Schedule 저장 — saveAll() 반환값(ID가 채워진 객체)을 사용해야 함
+        List<Schedule> schedules = ScheduleMapper.toSchedules(tripId, response);
+        List<Schedule> savedSchedules = scheduleRepository.saveAll(schedules);
+
+        // ScheduleItem 저장 — savedSchedules의 ID를 사용해야 scheduleId가 null이 아님
+        List<AiScheduleResponse.DayPlan> dayPlans = response.getItinerary().getDays();
+        for (int i = 0; i < savedSchedules.size(); i++) {
+            Schedule savedSchedule = savedSchedules.get(i);
+            AiScheduleResponse.DayPlan dayPlan = dayPlans.get(i);
+            List<ScheduleItem> items = ScheduleMapper.toScheduleItems(savedSchedule.getId(), dayPlan);
+            scheduleItemRepository.saveAll(items);
+        }
+
+        // 저장된 일정을 바로 반환 (Controller에서 프론트로 내려줌)
+        return getSchedules(tripId);
+    }
+
+    /**
+     * 특정 여행의 전체 일정 조회
+     * - day 오름차순, 각 day의 아이템은 orderIndex 오름차순
+     */
+    @Transactional(readOnly = true)
+    public List<ScheduleResponse> getSchedules(Long tripId) {
+
+        List<Schedule> schedules = scheduleRepository.findAllByTripId(tripId);
+
+        return schedules.stream()
+                .sorted((a, b) -> Integer.compare(a.getDay(), b.getDay()))
+                .map(schedule -> {
+                    List<ScheduleItemResponse> items = scheduleItemRepository
+                            .findAllByScheduleId(schedule.getId())
+                            .stream()
+                            .sorted((a, b) -> Integer.compare(a.getOrderIndex(), b.getOrderIndex()))
+                            .map(item -> ScheduleItemResponse.builder()
+                                    .id(item.getId())
+                                    .time(item.getTime())
+                                    .title(item.getTitle())
+                                    .category(item.getCategory())
+                                    .description(item.getDescription())
+                                    .orderIndex(item.getOrderIndex())
+                                    .lat(item.getLat())
+                                    .lng(item.getLng())
+                                    .build())
+                            .toList();
+
+                    return ScheduleResponse.builder()
+                            .scheduleId(schedule.getId())
+                            .day(schedule.getDay())
+                            .items(items)
+                            .build();
+                })
+                .toList();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #89 

---

## 🛠️ 작업 내용 (What)

- AI 일정 생성 API 구현 (POST /api/schedules/ai)
- 여행 Day 단위 Schedule 생성 및 DB 저장 로직 구현
- 일정 조회 API 구현 (GET /api/schedules)
- AI 응답 데이터를 Schedule / ScheduleItem 구조로 변환하는 Mapper 구현
- ScheduleAiService를 통한 AI 호출 흐름 구성

---

## 🧭 작업 목적 (Why)

- 사용자 입력 기반으로 자동 일정 생성 기능 제공
- 생성된 일정을 서버 DB에 저장하여 재사용 가능하도록 하기 위함
- 일정 데이터를 Day 단위로 구조화하여 관리하기 위함

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [x] DB 스키마

---

## 🧪 테스트 방법
- [x] POST /api/schedules/ai 호출 → 일정 생성 확인
- [x] GET /api/schedules 호출 → 일정 조회 확인
- [x] AI 응답 → DB 저장 정상 동작 확인
- [x] 예외 케이스 확인 (AI 응답 null 등)

---

## ⚠️ 참고 사항

- AI 응답 구조(day_1, day_2)를 동적으로 파싱하여 Schedule로 변환
- 일정 재생성 시 기존 데이터 삭제 후 저장하도록 처리
- ScheduleItem 생성은 Mapper에서 함께 처리됨
- ScheduleItem 엔티티는 생성 시점에서만 사용됨 (CRUD는 별도 PR)

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료