### PR TITLE
[BE] feature: ScheduleItem 타임라인 구조 및 CRUD/정렬/이동 구현

### DIFF
--- a/src/main/java/com/tripmoa/schedule/controller/ScheduleItemController.java
+++ b/src/main/java/com/tripmoa/schedule/controller/ScheduleItemController.java
@@ -1,0 +1,67 @@
+package com.tripmoa.schedule.controller;
+
+import com.tripmoa.schedule.dto.*;
+import com.tripmoa.schedule.service.ScheduleItemService;
+import com.tripmoa.security.principal.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/schedule-items")
+@RequiredArgsConstructor
+public class ScheduleItemController {
+
+    private final ScheduleItemService scheduleItemService;
+
+    // 노드추가
+    // POST /api/schedule-items
+    @PostMapping
+    public ResponseEntity<ScheduleItemResponse> create(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                       @RequestBody ScheduleItemCreateRequest request) {
+
+        return ResponseEntity.ok(scheduleItemService.create(request));
+    }
+
+    // 노드 수정
+    // PATCH /api/schedule-items/{itemId}
+    @PatchMapping("/{itemId}")
+    public ResponseEntity<ScheduleItemResponse> update(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                       @PathVariable Long itemId,
+                                                       @RequestBody ScheduleItemUpdateRequest request) {
+
+        return ResponseEntity.ok(scheduleItemService.update(itemId, request));
+    }
+
+    // 노드 삭제
+    // DELETE /api/schedule-items/{itemId}
+    @DeleteMapping("/{itemId}")
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                       @PathVariable Long itemId) {
+
+        scheduleItemService.delete(itemId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 순서 변경
+    // PATCH /api/schedule-items/reorder
+    @PatchMapping("/reorder")
+    public ResponseEntity<Void> reorder(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                        @RequestBody ScheduleItemReorderRequest request) {
+
+        scheduleItemService.reorder(request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 다른 날로 이동
+    // PATCH /api/schedule-items/{itemId}/move
+    @PatchMapping("/{itemId}/move")
+    public ResponseEntity<ScheduleItemResponse> move(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                     @PathVariable Long itemId,
+                                                     @RequestBody ScheduleItemMoveRequest request) {
+
+        return ResponseEntity.ok(scheduleItemService.move(itemId, request));
+    }
+
+}

--- a/src/main/java/com/tripmoa/schedule/domain/ScheduleItem.java
+++ b/src/main/java/com/tripmoa/schedule/domain/ScheduleItem.java
@@ -1,0 +1,63 @@
+package com.tripmoa.schedule.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * ScheduleItem (타임라인 단위)
+ *
+ * - 실제 일정 하나
+ * - 예: 09:00 경복궁 방문
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ScheduleItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 Day(Schedule)에 속하는지
+    private Long scheduleId;
+
+    // 시간 (09:00)
+    private String time;
+
+    // 제목 (경복궁)
+    private String title;
+
+    // 카테고리 (관광지, 맛집 등)
+    private String category;
+
+    // 상세 설명
+    @Column(length = 1000)
+    private String description;
+
+    // 순서 (정렬용)
+    private int orderIndex;
+
+    // 좌표 (지도 표시용)
+    private Double lat;
+    private Double lng;
+
+    // 노드 수정
+    public void update(String time, String title, String description) {
+        if (time != null) this.time = time;
+        if (title != null) this.title = title;
+        if (description != null) this.description = description;
+    }
+    // 순서 변경
+    public void updateOrder(int orderIndex) {
+        this.orderIndex = orderIndex;
+    }
+
+    // 다른 날로 이동
+    public void move(Long targetScheduleId, int orderIndex) {
+        this.scheduleId = targetScheduleId;
+        this.orderIndex = orderIndex;
+    }
+}

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleItemCreateRequest.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleItemCreateRequest.java
@@ -1,0 +1,11 @@
+package com.tripmoa.schedule.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ScheduleItemCreateRequest {
+    private Long scheduleId;   // 어떤 day에 추가할지
+    private String time;
+    private String title;
+    private String description;
+}

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleItemMoveRequest.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleItemMoveRequest.java
@@ -1,0 +1,11 @@
+package com.tripmoa.schedule.dto;
+
+import lombok.Getter;
+
+/**
+ * 다른 날로 이동 요청
+ */
+@Getter
+public class ScheduleItemMoveRequest {
+    private Long targetScheduleId;  // 이동할 대상 day의 scheduleId
+}

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleItemReorderRequest.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleItemReorderRequest.java
@@ -1,0 +1,13 @@
+package com.tripmoa.schedule.dto;
+
+import lombok.Getter;
+import java.util.List;
+
+/**
+ * 순서 변경 요청
+ * itemIds: 새로운 순서대로 정렬된 ScheduleItem id 목록
+ */
+@Getter
+public class ScheduleItemReorderRequest {
+    private List<Long> itemIds;
+}

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleItemResponse.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleItemResponse.java
@@ -1,0 +1,20 @@
+package com.tripmoa.schedule.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 타임라인 응답 DTO
+ */
+@Getter
+@Builder
+public class ScheduleItemResponse {
+    private Long id;
+    private String time;
+    private String title;
+    private String category;
+    private String description;
+    private int orderIndex;
+    private Double lat;
+    private Double lng;
+}

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleItemUpdateRequest.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleItemUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.tripmoa.schedule.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ScheduleItemUpdateRequest {
+    private String time;
+    private String title;
+    private String description;
+}

--- a/src/main/java/com/tripmoa/schedule/repository/ScheduleItemRepository.java
+++ b/src/main/java/com/tripmoa/schedule/repository/ScheduleItemRepository.java
@@ -1,0 +1,19 @@
+package com.tripmoa.schedule.repository;
+
+import com.tripmoa.schedule.domain.ScheduleItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * ScheduleItemRepository
+ * - 타임라인 조회
+ */
+public interface ScheduleItemRepository extends JpaRepository<ScheduleItem, Long> {
+
+    // 특정 Day의 타임라인
+    List<ScheduleItem> findAllByScheduleId(Long scheduleId);
+
+    // 특정 Day의 타임라인 전체 삭제 (일정 재생성 시 사용)
+    void deleteAllByScheduleId(Long scheduleId);
+}

--- a/src/main/java/com/tripmoa/schedule/service/ScheduleItemService.java
+++ b/src/main/java/com/tripmoa/schedule/service/ScheduleItemService.java
@@ -1,0 +1,113 @@
+package com.tripmoa.schedule.service;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.schedule.domain.ScheduleItem;
+import com.tripmoa.schedule.dto.*;
+import com.tripmoa.schedule.repository.ScheduleItemRepository;
+import com.tripmoa.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleItemService {
+
+    private final ScheduleItemRepository scheduleItemRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    // 노드 추가
+    @Transactional
+    public ScheduleItemResponse create(ScheduleItemCreateRequest request) {
+
+        // 1. schedule 존재 검증
+        scheduleRepository.findById(request.getScheduleId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        //해당 day의 현재 마지막 orderIndex 계산
+        List<ScheduleItem> existing = scheduleItemRepository.findAllByScheduleId(request.getScheduleId());
+
+        int nextOrder = existing.stream()
+                .mapToInt(ScheduleItem::getOrderIndex)
+                .max()
+                .orElse(-1) + 1;
+
+        ScheduleItem item = ScheduleItem.builder()
+                .scheduleId(request.getScheduleId())
+                .time(request.getTime() != null ? request.getTime() : "00:00")
+                .title(request.getTitle() != null ? request.getTitle() : "NEW")
+                .description(request.getDescription() != null ? request.getDescription() : "")
+                .orderIndex(nextOrder)
+                .build();
+
+        return toResponse(scheduleItemRepository.save(item));
+    }
+
+    // 노드 수정
+    @Transactional
+    public ScheduleItemResponse update(Long itemId, ScheduleItemUpdateRequest request) {
+        ScheduleItem item = scheduleItemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        item.update(request.getTime(), request.getTitle(), request.getDescription());
+        return toResponse(item);
+    }
+
+    // 노드 삭제
+    @Transactional
+    public void delete(Long itemId) {
+        scheduleItemRepository.deleteById(itemId);
+    }
+
+    // 순서 변경 — itemIds 순서대로 orderIndex 재할당
+    @Transactional
+    public void reorder(ScheduleItemReorderRequest request) {
+
+        List<Long> itemIds = request.getItemIds();
+
+        for (int i = 0; i < itemIds.size(); i++) {
+            ScheduleItem item = scheduleItemRepository.findById(itemIds.get(i))
+                    .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+            item.updateOrder(i);
+        }
+    }
+
+    // 다른 날로 이동
+    @Transactional
+    public ScheduleItemResponse move(Long itemId, ScheduleItemMoveRequest request) {
+        ScheduleItem item = scheduleItemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        scheduleRepository.findById(request.getTargetScheduleId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        // 대상 day의 마지막 orderIndex 계산
+        List<ScheduleItem> targetItems = scheduleItemRepository.findAllByScheduleId(request.getTargetScheduleId());
+
+        int nextOrder = targetItems.stream()
+                .mapToInt(ScheduleItem::getOrderIndex)
+                .max()
+                .orElse(-1) + 1;
+
+        item.move(request.getTargetScheduleId(), nextOrder);
+
+        return toResponse(item);
+    }
+
+    private ScheduleItemResponse toResponse(ScheduleItem item) {
+        return ScheduleItemResponse.builder()
+                .id(item.getId())
+                .time(item.getTime())
+                .title(item.getTitle())
+                .category(item.getCategory())
+                .description(item.getDescription())
+                .orderIndex(item.getOrderIndex())
+                .lat(item.getLat())
+                .lng(item.getLng())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #90 

---

## 🛠️ 작업 내용 (What)

- ScheduleItem 엔티티 설계
- 타임라인 노드 CRUD API 구현
- 노드 순서 변경(reorder) 기능 구현
- 노드 다른 Day로 이동(move) 기능 구현

---

## 🧭 작업 목적 (Why)

- 사용자가 일정 타임라인을 직접 수정 가능하도록 하기 위함
- 일정 구성의 유연성 및 사용자 인터랙션 지원

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [x] DB 스키마

---

## 🧪 테스트 방법
- [x] POST /api/schedule-items → 노드 생성 확인
- [x] PATCH → 수정 확인
- [x] DELETE → 삭제 확인
- [x] reorder → 순서 변경 확인
- [x] move → Day 이동 확인

---

## ⚠️ 참고 사항

- orderIndex 기준으로 타임라인 정렬 처리
- move 시 대상 Day의 마지막 index로 이동하도록 구현
- Schedule 존재 여부 검증 후 생성/이동 처리

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료