### PR TITLE
[BE] feature: 일정 생성에서 Place(장소) CRUD 및 AI 검색 기능 구현

### DIFF
--- a/src/main/java/com/tripmoa/place/controller/PlaceController.java
+++ b/src/main/java/com/tripmoa/place/controller/PlaceController.java
@@ -1,0 +1,74 @@
+package com.tripmoa.place.controller;
+
+import com.tripmoa.place.domain.Place;
+import com.tripmoa.place.dto.PlaceCreateRequest;
+import com.tripmoa.place.dto.PlaceResponse;
+import com.tripmoa.place.dto.PlaceUpdateRequest;
+import com.tripmoa.place.service.PlaceService;
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.trip.service.TripPermissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * PlaceController
+ *
+ * - 장소 API
+ */
+@RestController
+@RequestMapping("/api/places")
+@RequiredArgsConstructor
+public class PlaceController {
+
+    private final PlaceService placeService;
+    private final TripPermissionService tripPermissionService;
+
+    //장소 저장 POST /api/places
+    @PostMapping
+    public ResponseEntity<PlaceResponse> create(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                @RequestBody PlaceCreateRequest request) {
+
+        Long userId = userDetails.getUser().getId();
+        tripPermissionService.assertOwnerOrMember(request.getTripId(), userId);
+
+        return ResponseEntity.ok(placeService.save(request));
+    }
+
+    // 장소 조회 GET /api/places?tripId=1
+    @GetMapping
+    public ResponseEntity<List<PlaceResponse>> get(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                   @RequestParam Long tripId) {
+
+        Long userId = userDetails.getUser().getId();
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+
+        return ResponseEntity.ok(placeService.getPlaces(tripId));
+    }
+
+    // 카테고리 / 메모 수정
+    @PatchMapping("/{placeId}")
+    public ResponseEntity<PlaceResponse> update(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long placeId,
+            @RequestBody PlaceUpdateRequest request
+    ) {
+        // placeId만으로 tripId를 알 수 없어서 권한 체크는 서비스 레이어에서 처리
+        return ResponseEntity.ok(placeService.update(placeId, request));
+    }
+
+    // 장소 삭제 DELETE /api/places/{placeId}
+    @DeleteMapping("/{placeId}")
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                       @PathVariable Long placeId) {
+
+        // 삭제는 placeId만으로 처리 (PlaceService 내부에서 처리)
+        placeService.deletePlace(placeId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/tripmoa/place/controller/PlaceSearchController.java
+++ b/src/main/java/com/tripmoa/place/controller/PlaceSearchController.java
@@ -1,0 +1,35 @@
+package com.tripmoa.place.controller;
+
+import com.tripmoa.ai.domain.AiClient;
+import com.tripmoa.place.dto.PlaceSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * PlaceSearchController
+ * GET /api/places/search?query=경복궁&display=12
+ * → AiClient → Python /schedule/search
+ */
+@RestController
+@RequestMapping("/api/places")
+@RequiredArgsConstructor
+public class PlaceSearchController {
+
+    private final AiClient aiClient;
+
+    @GetMapping("/search")
+    public ResponseEntity<PlaceSearchResponse> search(@RequestParam String query, @RequestParam(defaultValue = "12") int display) {
+
+        PlaceSearchResponse response = aiClient.search(query, display);
+
+        if (response == null) {
+            return ResponseEntity.ok(new PlaceSearchResponse());
+        }
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/tripmoa/place/domain/Place.java
+++ b/src/main/java/com/tripmoa/place/domain/Place.java
@@ -1,0 +1,50 @@
+package com.tripmoa.place.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Place (장소 엔티티)
+ *
+ * - 여행(trip)에 속한 장소를 저장
+ * - 기존 프론트 localStorage → DB로 이동시키는 핵심 엔티티
+ */
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Place {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long tripId;
+
+    // 장소 이름
+    private String name;
+    
+    // 카테고리(관광지, 맛집)
+    private String category;
+
+    // 위도/경도
+    private Double lat;
+    private Double lng;
+
+    // 추가: 주소
+    private String address;
+
+    @Column(length = 500)
+    private String description;  // 추가: 장소 설명
+
+    // 사용자 장소 메모
+    private String memo;
+
+    // 카테고리, 메모 수정
+    public void update(String category, String memo) {
+        if (category != null) this.category = category;
+        if (memo != null) this.memo = memo;
+    }
+}

--- a/src/main/java/com/tripmoa/place/dto/PlaceCreateRequest.java
+++ b/src/main/java/com/tripmoa/place/dto/PlaceCreateRequest.java
@@ -1,0 +1,25 @@
+package com.tripmoa.place.dto;
+
+import lombok.Getter;
+
+/**
+ * Place 생성 요청 DTO
+ *
+ * - 프론트 → 백엔드 요청용
+ * - entity 직접 받지 않고 DTO로 받는 게 정석
+ */
+@Getter
+public class PlaceCreateRequest {
+
+    private Long tripId;
+
+    private String name;
+    private String category;
+
+    private Double lat;
+    private Double lng;
+
+    private String address;
+    private String description;
+    private String memo;
+}

--- a/src/main/java/com/tripmoa/place/dto/PlaceResponse.java
+++ b/src/main/java/com/tripmoa/place/dto/PlaceResponse.java
@@ -1,0 +1,43 @@
+package com.tripmoa.place.dto;
+
+import com.tripmoa.place.domain.Place;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Place 응답 DTO
+ *
+ * - 백엔드 → 프론트 반환용
+ */
+@Getter
+@Builder
+public class PlaceResponse {
+
+    private Long id;
+    private Long tripId;
+
+    private String name;
+    private String category;
+
+    private Double lat;
+    private Double lng;
+
+    private String address;
+    private String description;
+    private String memo;
+
+    //Entity -> Dto 변환
+    public static PlaceResponse from(Place place) {
+        return PlaceResponse.builder()
+                .id(place.getId())
+                .tripId(place.getTripId())
+                .name(place.getName())
+                .category(place.getCategory())
+                .lat(place.getLat())
+                .lng(place.getLng())
+                .address(place.getAddress())
+                .description(place.getDescription())
+                .memo(place.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/tripmoa/place/dto/PlaceSearchResponse.java
+++ b/src/main/java/com/tripmoa/place/dto/PlaceSearchResponse.java
@@ -1,0 +1,35 @@
+package com.tripmoa.place.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Python 검색 API 응답 → 프론트 전달용 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class PlaceSearchResponse {
+
+    private boolean success;
+    private int total;
+    private int display;
+    private List<PlaceSearchItem> places;
+    private String query;
+    private String method;
+
+    @Getter
+    @NoArgsConstructor
+    public static class PlaceSearchItem {
+        private String name;
+        private String address;
+        private Double lat;
+        private Double lng;
+        private String category;
+        private String description;
+        private String telephone;
+        private String link;
+    }
+
+}

--- a/src/main/java/com/tripmoa/place/dto/PlaceUpdateRequest.java
+++ b/src/main/java/com/tripmoa/place/dto/PlaceUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.tripmoa.place.dto;
+
+import lombok.Getter;
+
+/**
+ * 장소 수정 요청 DTO (카테고리, 메모만 수정 가능)
+ */
+@Getter
+public class PlaceUpdateRequest {
+    private String category;
+    private String memo;
+}

--- a/src/main/java/com/tripmoa/place/repository/PlaceRepository.java
+++ b/src/main/java/com/tripmoa/place/repository/PlaceRepository.java
@@ -1,0 +1,15 @@
+package com.tripmoa.place.repository;
+
+import com.tripmoa.place.domain.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+/**
+ * PlaceRepository
+ * - 장소 DB 접근
+ */
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+    // 특정 여행의 장소 목록 조회
+    List<Place> findAllByTripId(Long tripId);
+}

--- a/src/main/java/com/tripmoa/place/service/PlaceService.java
+++ b/src/main/java/com/tripmoa/place/service/PlaceService.java
@@ -1,0 +1,65 @@
+package com.tripmoa.place.service;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.place.domain.Place;
+import com.tripmoa.place.dto.PlaceCreateRequest;
+import com.tripmoa.place.dto.PlaceResponse;
+import com.tripmoa.place.dto.PlaceUpdateRequest;
+import com.tripmoa.place.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * PlaceService
+  * - 장소 관련 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+
+    // 장소 생성
+    public PlaceResponse save(PlaceCreateRequest request) {
+        Place place = Place.builder()
+                .tripId(request.getTripId())
+                .name(request.getName())
+                .category(request.getCategory())
+                .lat(request.getLat())
+                .lng(request.getLng())
+                .address(request.getAddress())
+                .description(request.getDescription())
+                .memo(request.getMemo())
+                .build();
+
+        return PlaceResponse.from(placeRepository.save(place));
+    }
+    
+    // 장소 조회
+    public List<PlaceResponse> getPlaces(Long tripId) {
+        return placeRepository.findAllByTripId(tripId)
+                .stream()
+                .map(PlaceResponse::from)
+                .toList();
+    }
+
+    // 장소 카테고리/메모 수정
+    @Transactional
+    public PlaceResponse update(Long placeId, PlaceUpdateRequest request) {
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        place.update(request.getCategory(), request.getMemo());
+
+        return PlaceResponse.from(place);
+    }
+
+    //장소 삭제
+    public void deletePlace(Long placeId) {
+        placeRepository.deleteById(placeId);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #91 

---

## 🛠️ 작업 내용 (What)

- Place 엔티티 설계
- 장소 CRUD API 구현
- AI 서버 기반 장소 검색 API 구현

---

## 🧭 작업 목적 (Why)

- 사용자 여행 장소 데이터를 서버 DB에서 관리하기 위함
- AI 일정 생성에 필요한 장소 데이터를 제공하기 위함

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [x] DB 스키마

---

## 🧪 테스트 방법
- [x] POST /api/places → 장소 생성 확인
- [x] GET /api/places → 조회 확인
- [x] PATCH → 수정 확인
- [x] DELETE → 삭제 확인
- [x] GET /api/places/search → 검색 결과 확인

---

## ⚠️ 참고 사항

- tripId 기준으로 장소 관리
- 장소 검색은 AI 서버를 프록시 방식으로 호출
- 검색 실패 시 빈 객체 반환 처리

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료