### PR TITLE
[BE] feature: AI 서버 연동 및 Security 설정 수정

### DIFF
--- a/src/main/java/com/tripmoa/ai/domain/AiClient.java
+++ b/src/main/java/com/tripmoa/ai/domain/AiClient.java
@@ -1,0 +1,44 @@
+package com.tripmoa.ai.domain;
+
+import com.tripmoa.ai.dto.AiScheduleRequest;
+import com.tripmoa.ai.dto.AiScheduleResponse;
+import com.tripmoa.place.dto.PlaceSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * AiClient
+ * - Python AI 서버와 통신하는 전용 클래스
+ * - 일정 생성 + 장소 검색 두 가지 역할
+ */
+@Component
+@RequiredArgsConstructor
+public class AiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    // AI 일정 생성
+    public AiScheduleResponse generate(AiScheduleRequest request) {
+        String url = aiServerUrl + "/schedule/generate";
+        return restTemplate.postForObject(url, request, AiScheduleResponse.class);
+    }
+
+    // 장소 검색 프록시
+    public PlaceSearchResponse search(String query, int display) {
+        // Spring이 @RequestParam으로 이미 디코딩한 query를 UriComponentsBuilder로 다시 인코딩
+        java.net.URI uri = UriComponentsBuilder
+                .fromUriString(aiServerUrl + "/schedule/search")
+                .queryParam("query", query)
+                .queryParam("display", display)
+                .build()
+                .encode()
+                .toUri();
+        return restTemplate.getForObject(uri, PlaceSearchResponse.class);
+    }
+}

--- a/src/main/java/com/tripmoa/ai/dto/AiScheduleRequest.java
+++ b/src/main/java/com/tripmoa/ai/dto/AiScheduleRequest.java
@@ -1,0 +1,40 @@
+package com.tripmoa.ai.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * AiScheduleRequest
+ *
+ * - Spring → Python(AI 서버) 요청 DTO
+ * - 프론트에서 받은 데이터를 Python 서버 형식으로 변환해서 전달
+ *
+ * 주의
+ * - 필드명 반드시 Python 서버와 동일해야 함
+ *   (n_days 이런 스네이크 케이스 유지)
+ */
+@Getter
+@Builder
+public class AiScheduleRequest {
+
+    //장소 리스트
+    // 예:[{ "name": "경복궁", "lat": 37.5, "lng": 126.9, "category": "관광지" }]
+    private List<Object> places;
+
+    //여행 일수(Python 서버에서 일정 분배 기준으로 사용)
+    private int n_days;
+
+    private String transportation_mode;
+    private String start_date;
+    private String end_date;
+    private String daily_start_time;
+    private String daily_end_time;
+
+    private Object user_preferences;
+    private List<Object> pinned_places;
+    private List<Object> hotels;
+    private List<Object> departure_points;
+}

--- a/src/main/java/com/tripmoa/ai/dto/AiScheduleResponse.java
+++ b/src/main/java/com/tripmoa/ai/dto/AiScheduleResponse.java
@@ -1,0 +1,104 @@
+//package com.tripmoa.ai.dto;
+//
+//import lombok.Getter;
+//
+//import java.util.List;
+//
+///**
+// * AiScheduleResponse
+// * - Python → Spring 응답 DTO
+// * - AI가 생성한 일정 구조를 그대로 받는다
+// * 구조 반드시 Python 응답과 일치해야 함
+// */
+//@Getter
+//public class AiScheduleResponse {
+//
+//    //Day 단위 일정 리스트
+//    private List<DayPlan> days;
+//
+//    //DayPlan (하루 일정)
+//    @Getter
+//    public static class DayPlan {
+//        // 몇 번째 날인지
+//        private int day;
+//
+//        // 해당 날짜의 일정 리스트
+//        private List<Item> items;
+//    }
+//
+//    // Item 개별 일정
+//    @Getter
+//    public static class Item {
+//        //시간 (예: "09:00")
+//        private String time;
+//
+//        //일정 제목 (예: "경복궁 방문")
+//        private String title;
+//
+//        //상세 설명
+//        private String description;
+//    }
+//
+//}
+package com.tripmoa.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AiScheduleResponse
+ * Python 응답 구조:
+ * {
+ *   "success": true,
+ *   "itinerary": {
+ *     "day_1": { "places": [...] },
+ *     "day_2": { "places": [...] }
+ *   }
+ * }
+ */
+@Getter
+public class AiScheduleResponse {
+
+    private boolean success;
+    private Itinerary itinerary;
+
+    @Getter
+    public static class Itinerary {
+        private List<DayPlan> days = new ArrayList<>();
+
+        // "day_1", "day_2" 같은 동적 키를 받아서 days 리스트로 변환
+        @JsonAnySetter
+        public void addDay(String key, DayPlan dayPlan) {
+            if (key.startsWith("day_")) {
+                int dayNum = Integer.parseInt(key.replace("day_", ""));
+                dayPlan.setDay(dayNum);
+                days.add(dayPlan);
+            }
+        }
+    }
+
+    @Getter
+    public static class DayPlan {
+        private int day;
+        private List<Item> places;  // Python에서 "places" 필드로 옴
+
+        public void setDay(int day) {
+            this.day = day;
+        }
+    }
+
+    @Getter
+    public static class Item {
+        private String time;
+        private String place;        // Python에서 "place" 필드로 옴 (title 아님)
+        private String category;
+        private String address;
+        private String description;
+        private Double lat;
+        private Double lng;
+    }
+}

--- a/src/main/java/com/tripmoa/global/config/SecurityConfig.java
+++ b/src/main/java/com/tripmoa/global/config/SecurityConfig.java
@@ -80,6 +80,11 @@ public class SecurityConfig {
                         // 소셜 로그인 관련 경로 : 인증 없이 접근 가능
                         .requestMatchers("/oauth2/**", "/login/oauth2/**", "/api/auth/**", "/api/test/**").permitAll()
 
+                        // Schedule : 일정 생성 Ai 호출
+                        .requestMatchers("/api/schedules/**").permitAll()
+                        .requestMatchers("/api/places/**").permitAll()
+                        .requestMatchers("/api/schedule-items/**").permitAll()
+
                         // 비로그인 사용자도 볼 수 있는 데이터 (Public API) GET 경로만 허용
                         .requestMatchers(HttpMethod.GET, "/api/travelstory/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/mate/**").permitAll()


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #92 

---

## 🛠️ 작업 내용 (What)

- AI 서버 통신을 위한 AiClient 구현
- AI 요청/응답 DTO 정의
- Spring Security 설정 수정 (API 접근 허용 경로 추가)

---

## 🧭 작업 목적 (Why)

- 외부 AI 서버와의 통신 기반 마련
- 일정 및 장소 API 접근 제어 설정 적용

---

## 🧩 변경 범위
- [ ] Controller
- [ ] Service
- [ ] Domain(Entity)
- [ ] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] AI 서버 호출 테스트
- [x] API 접근 권한 확인
- [x] 인증 없이 접근 가능한 경로 검증

---

## ⚠️ 참고 사항

- AI 서버 URL은 application.yml 설정값 사용
- SecurityConfig에서 /api/schedules, /api/places, /api/schedule-items 경로 permitAll 설정
- JWT 필터 구조 유지

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료