### PR TITLE
[BE] feature: 메이트 작성&신청 시 금칙어 필터링 적용

### DIFF
--- a/src/main/java/com/tripmoa/mate/service/MateApplicationService.java
+++ b/src/main/java/com/tripmoa/mate/service/MateApplicationService.java
@@ -1,5 +1,6 @@
 package com.tripmoa.mate.service;
 
+import com.tripmoa.global.util.BadWordFilter;
 import com.tripmoa.mate.domain.MateApplication;
 import com.tripmoa.mate.domain.MateDomain;
 import com.tripmoa.mate.domain.MatePost;
@@ -25,6 +26,7 @@ public class MateApplicationService {
     private final MateDomain domain;
     private final MateRepository mateRepository;
     private final ApplicationRepository applyRepository;
+    private final BadWordFilter badWordFilter;
 
     public List<ApplicationResponse> getReceivedApplication(Long ownerId) {
         List<MateApplication> applications  = this.applyRepository.findByOwnerId(ownerId); // 내가 쓴 포스트로 조회
@@ -47,6 +49,10 @@ public class MateApplicationService {
 
         if(post.getEndDate().isBefore(LocalDate.now())) {
             throw new BusinessException(ErrorCode.MATE_POST_EXPIRED);
+        }
+
+        if (badWordFilter.containsBadWord(request.getContent())) {
+            throw new BusinessException(ErrorCode.BAD_WORD_DETECTED);
         }
 
         domain.validateProfileCompleteness(applicant);

--- a/src/main/java/com/tripmoa/mate/service/MateService.java
+++ b/src/main/java/com/tripmoa/mate/service/MateService.java
@@ -1,5 +1,6 @@
 package com.tripmoa.mate.service;
 
+import com.tripmoa.global.util.BadWordFilter;
 import com.tripmoa.mate.domain.MatePost;
 import com.tripmoa.mate.domain.MateDomain;
 import com.tripmoa.mate.dto.MateRequest;
@@ -32,6 +33,7 @@ public class MateService {
     private final PassedPostService passedPostService;
     private final ViewCountService viewCountService;
     private final MateDomain domain;
+    private final BadWordFilter badWordFilter;
 
     public List<MateResponse> getMatePosts(Long userId) {
         List<MatePost> matePosts = mateRepository.findAllWithUser();
@@ -63,6 +65,11 @@ public class MateService {
 
     @Transactional
     public MateResponse createPost(MateRequest request, User user) {
+        if (badWordFilter.containsBadWord(request.getContent())
+                || badWordFilter.containsBadWord(request.getDestination())) {
+            throw new BusinessException(ErrorCode.BAD_WORD_DETECTED);
+        }
+
         domain.validateProfileCompleteness(user);
         MatePost post = request.toEntity(user);
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #97

---

## 🛠️ 작업 내용 (What)
- `MateService`에 글 작성 시 `BadWordFilter` 금칙어 검사 추가 (제목/내용/여행지)
- `MateApplicationService`에 신청 시 `BadWordFilter` 금칙어 검사 추가 (신청 메시지)

---

## 🧭 작업 목적 (Why)
부적절한 단어가 포함된 메이트 글/신청이 등록되는 것을 사전에 방지하여 커뮤니티 환경을 보호함
채팅은 별도 신고 기능이 있으므로 적용 제외.

---

## 🧩 변경 범위
- [ ] Controller
- [x] Service
- [ ] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
  - `POST /api/mates` — 제목/내용/여행지에 금칙어 포함 시 400 응답 확인
  - `POST /api/mates/{postId}/applications` — 신청 메시지에 금칙어 포함 시 400 응답 확인
- [x] 예외 케이스 확인
  - 금칙어 없는 정상 요청 통과 확인

---

## ⚠️ 참고 사항
- 기존 `BadWordFilter` 유틸리티를 그대로 활용, 신규 의존성 없음
- 프론트는 기존 `catch` 블록의 `err.response?.data?.message`로 에러 메시지 표시되므로 별도 수정 불필요

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료