### PR TITLE
[BE] auth: OAuth2 로그인 및 인증/인가 구조 개선

### DIFF
--- a/src/main/java/com/tripmoa/global/config/OAuth2Config.java
+++ b/src/main/java/com/tripmoa/global/config/OAuth2Config.java
@@ -1,0 +1,28 @@
+package com.tripmoa.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+
+@Configuration
+public class OAuth2Config {
+
+    @Bean
+    public OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository) {
+
+        DefaultOAuth2AuthorizationRequestResolver resolver =
+                new DefaultOAuth2AuthorizationRequestResolver(
+                        clientRegistrationRepository, "/oauth2/authorization");
+
+        resolver.setAuthorizationRequestCustomizer(customizer ->
+                customizer.additionalParameters(params ->
+                        params.put("auth_type", "reauthenticate")  // 자동로그인 방지
+                )
+        );
+
+        return resolver;
+    }
+}

--- a/src/main/java/com/tripmoa/global/config/SecurityConfig.java
+++ b/src/main/java/com/tripmoa/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.tripmoa.security.jwt.JwtAuthenticationEntryPoint;
 import com.tripmoa.security.jwt.JwtAuthenticationFilter;
 import com.tripmoa.security.jwt.JwtTokenProvider;
 import com.tripmoa.security.oauth.CustomOAuth2UserService;
+import com.tripmoa.security.oauth.OAuth2FailureHandler;
 import com.tripmoa.security.oauth.OAuth2SuccessHandler;
 import com.tripmoa.security.principal.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -42,11 +44,17 @@ public class SecurityConfig {
     // 소셜 로그인 성공 시 JWT 발급하고 프론트로 전달하는 핸들러
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
+    // 소셜 로그인 실패 시 프론트로 전달하는 핸들러
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+
     // 인증 실패 시 401 JSON 응답 커스텀하고 싶을 때 사용
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     // 실제 사용자(User)를 DB에서 조회하기 위한 서비스
     private final CustomUserDetailsService customUserDetailsService;
+
+    // OAuth2 인증 요청 시 추가 파라미터를 커스터마이징하기 위한 Resolver
+    private final OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -70,7 +78,7 @@ public class SecurityConfig {
                         // 외부 접근 차단
                         .requestMatchers("/api/v1/ocr/**").denyAll()
 
-                        // OCR 프록시: 로그인 필요
+                        // OCR 프록시: 로그인 필요 (의도적으로 명시)
                         .requestMatchers(HttpMethod.POST, "/api/trips/*/expenses/ocr/**").authenticated()
 
                         // Mate : 로그인 필요한 엔드포인트
@@ -86,7 +94,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/schedule-items/**").permitAll()
 
                         // 비로그인 사용자도 볼 수 있는 데이터 (Public API) GET 경로만 허용
-                        .requestMatchers(HttpMethod.GET, "/api/travelstory/**").permitAll()
+                        // .requestMatchers(HttpMethod.GET, "/api/stories/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/mate/**").permitAll()
 
                         // Swagger 경로 허용
@@ -107,6 +115,12 @@ public class SecurityConfig {
 
                 // OAuth2 로그인 설정
                 .oauth2Login(oauth -> oauth
+                        // 자동로그인 방지
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .authorizationRequestResolver(customAuthorizationRequestResolver)
+                        )
+                        // 로그인 실패 핸들러
+                        .failureHandler(oAuth2FailureHandler)
                         // 로그인 성공 -> 소셜 로그인 사용자 정보 로딩
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         // 로그인 성공 핸들러 -> JWT 토큰 발행 및 리다이렉트

--- a/src/main/java/com/tripmoa/security/oauth/OAuth2FailureHandler.java
+++ b/src/main/java/com/tripmoa/security/oauth/OAuth2FailureHandler.java
@@ -1,0 +1,36 @@
+package com.tripmoa.security.oauth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Value("${oauth2.redirect-url}")
+    private String frontendUrl;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+
+        // access_denied(취소) 조용히 처리
+        if (exception instanceof OAuth2AuthenticationException oauth2Ex) {
+            String errorCode = oauth2Ex.getError().getErrorCode();
+            if ("access_denied".equals(errorCode)) {
+                response.sendRedirect(frontendUrl + "/login");
+                return;
+            }
+        }
+
+        // 그 외 실제 오류만 에러 표시
+        response.sendRedirect(frontendUrl + "/login?error=true");
+    }
+}

--- a/src/main/java/com/tripmoa/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/tripmoa/security/oauth/OAuth2SuccessHandler.java
@@ -1,5 +1,7 @@
 package com.tripmoa.security.oauth;
 
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.security.jwt.JwtTokenProvider;
 import com.tripmoa.user.entity.User;
 import com.tripmoa.user.service.AuthService;
@@ -54,7 +56,27 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String provider = oauthToken.getAuthorizedClientRegistrationId().toUpperCase();
 
         // 리프레시 토큰 생성 및 DB 저장
-        String refreshToken = authService.createAndSaveRefreshToken(user);
+        String refreshToken;
+
+        try {
+            refreshToken = authService.createAndSaveRefreshToken(user);
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.ACCOUNT_SUSPENDED) {
+                getRedirectStrategy().sendRedirect(
+                        request,
+                        response,
+                        redirectBaseUrl + "/login?error=SUSPENDED"
+                );
+                return;
+            }
+
+            getRedirectStrategy().sendRedirect(
+                    request,
+                    response,
+                    redirectBaseUrl + "/login?error=true"
+            );
+            return;
+        }
 
         ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)

--- a/src/main/java/com/tripmoa/security/principal/CustomUserDetailsService.java
+++ b/src/main/java/com/tripmoa/security/principal/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.tripmoa.security.principal;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.user.entity.User;
+import com.tripmoa.user.enums.UserStatus;
 import com.tripmoa.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,8 +31,27 @@ public class CustomUserDetailsService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+        // 정지/탈퇴 등 비활성 상태 사용자는 인증 불가
+        validateActiveUser(user);
+
         // User 엔티티를 CustomUserDetails로 감싸서 반환
         return new CustomUserDetails(user);
+    }
+
+    /**
+     * 현재 로그인 가능한 상태의 사용자만 통과
+     * - ACTIVE     : 정상 이용 가능
+     * - SUSPENDED  : 신고 정책에 따른 계정 정지
+     * - WITHDRAWN  : 탈퇴 사용자
+     */
+    private void validateActiveUser(User user) {
+        if (user.getStatus() == UserStatus.SUSPENDED) {
+            throw new BusinessException(ErrorCode.ACCOUNT_SUSPENDED);
+        }
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.USER_FORBIDDEN);
+        }
     }
 }
 

--- a/src/main/java/com/tripmoa/user/controller/AuthController.java
+++ b/src/main/java/com/tripmoa/user/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.tripmoa.user.controller;
 
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.user.service.AuthService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -27,9 +29,12 @@ public class AuthController {
             @CookieValue(value = "refreshToken", required = false) String refreshToken,
             HttpServletResponse response
     ) {
-        // 토큰이 없는 경우 처리
+        // 토큰이 없는 경우 비로그인 상태
         if (refreshToken == null || refreshToken.isBlank()) {
-            return ResponseEntity.ok(Map.of("authenticated", false));
+            return ResponseEntity.ok(Map.of(
+                    "authenticated", false,
+                    "reason", "UNAUTHENTICATED"
+            ));
         }
 
         try {
@@ -52,8 +57,8 @@ public class AuthController {
                     "authenticated", true
             ));
 
-        } catch (RuntimeException e) {
-            // 토큰 만료/위조 등 예상된 케이스 → 쿠키 삭제 + authenticated: false
+        } catch (BusinessException e) {
+            // 인증 유지 불가 상황 → Refresh 쿠키 제거 후 상태값과 함께 응답
             ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
                     .httpOnly(true)
                     .secure(false)
@@ -63,10 +68,37 @@ public class AuthController {
                     .build();
             response.addHeader("Set-Cookie", deleteCookie.toString());
 
-            return ResponseEntity.ok(Map.of("authenticated", false));
+            if (e.getErrorCode() == ErrorCode.ACCOUNT_SUSPENDED) {
+                return ResponseEntity.ok(Map.of(
+                        "authenticated", false,
+                        "reason", "SUSPENDED",
+                        "message", "신고 정책으로 정지된 계정입니다."
+                ));
+            }
+
+            return ResponseEntity.ok(Map.of(
+                    "authenticated", false,
+                    "reason", "UNAUTHENTICATED"
+            ));
+
+        } catch (RuntimeException e) {
+            // 토큰 만료/위조 등 일반 인증 실패
+            ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                    .httpOnly(true)
+                    .secure(false)
+                    .path("/")
+                    .sameSite("Lax")
+                    .maxAge(0)
+                    .build();
+            response.addHeader("Set-Cookie", deleteCookie.toString());
+
+            return ResponseEntity.ok(Map.of(
+                    "authenticated", false,
+                    "reason", "UNAUTHENTICATED"
+            ));
 
         } catch (Exception e) {
-            // DB 장애 등 서버 오류 → 쿠키 건드리지 않고 500 반환
+            // DB 장애 등 예상하지 못한 서버 오류
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/src/main/java/com/tripmoa/user/service/AuthService.java
+++ b/src/main/java/com/tripmoa/user/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.tripmoa.user.service;
 
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.security.jwt.JwtTokenProvider;
 import com.tripmoa.user.entity.RefreshToken;
 import com.tripmoa.user.entity.User;
@@ -20,11 +22,14 @@ public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final UserRepository userRepository;
+    private final UserGuardService userGuardService;
+
 
     // 로그인 시 리프레시 토큰 저장/갱신
     @Transactional
     public String createAndSaveRefreshToken(User user) {
+        validateActiveUser(user);
+
         String refreshTokenValue = jwtTokenProvider.createRefreshToken(user.getId());
         LocalDateTime expiryDate = LocalDateTime.now().plusDays(14);
 
@@ -32,9 +37,10 @@ public class AuthService {
                 .orElse(null);
 
         if (refreshToken != null) {
+            // 기존 토큰이 있으면 값과 만료일만 갱신
             refreshToken.updateToken(refreshTokenValue, expiryDate);
         } else {
-            // 새로운 토큰 저장
+            // 기존 토큰이 없으면 새로 저장
             refreshTokenRepository.save(new RefreshToken(user, refreshTokenValue, expiryDate));
         }
 
@@ -44,8 +50,7 @@ public class AuthService {
     // 로그아웃 시 DB 토큰 삭제 로직 추가
     @Transactional
     public void logout(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+        User user = userGuardService.getUserOr404(userId);
         refreshTokenRepository.deleteByUser(user);
     }
 
@@ -64,10 +69,15 @@ public class AuthService {
 
         User user = storedToken.getUser();
 
-        if (user.getStatus() != UserStatus.ACTIVE) {
+        // 정지/탈퇴 등 비활성 사용자 차단
+        if (user.getStatus() == UserStatus.SUSPENDED) {
             refreshTokenRepository.delete(storedToken);
             refreshTokenRepository.flush();
-            throw new RuntimeException("비활성 사용자입니다.");
+            throw new BusinessException(ErrorCode.ACCOUNT_SUSPENDED);
+        }
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            refreshTokenRepository.delete(storedToken);
+            throw new BusinessException(ErrorCode.USER_FORBIDDEN);
         }
 
         // 토큰 발급
@@ -81,5 +91,21 @@ public class AuthService {
         tokens.put("accessToken", newAccess);
         tokens.put("refreshToken", newRefresh);
         return tokens;
+    }
+
+    // 로그인 가능한 사용자 상태인지 확인
+    private void validateActiveUser(User user) {
+        if (user.getStatus() == UserStatus.SUSPENDED) {
+            RefreshToken storedToken = refreshTokenRepository.findByUser(user).orElse(null);
+            if (storedToken != null) {
+                refreshTokenRepository.delete(storedToken);
+                refreshTokenRepository.flush();
+            }
+            throw new BusinessException(ErrorCode.ACCOUNT_SUSPENDED);
+        }
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.USER_FORBIDDEN);
+        }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #99

---

## 🛠️ 작업 내용 (What)

OAuth2 로그인 및 인증/인가 구조 전반을 개선했습니다.

- OAuth2 로그인 시 자동 로그인 방지 로직 추가
- SecurityConfig OAuth2 설정 및 인증 흐름 개선
- OAuth2SuccessHandler 토큰 발급 및 응답 구조 수정
- OAuth2FailureHandler 로그인 취소 처리 개선
- CustomUserDetailsService 비활성 사용자 인증 차단 로직 추가
- AuthController 인증 상태 응답 구조 개선
- AuthService 리프레시 토큰 검증 및 재발급 로직 강화

---

## 🧭 작업 목적 (Why)

기존 OAuth2 로그인 흐름에서 발생할 수 있는 문제를 개선하고  
인증/인가 구조를 안정적으로 정리하기 위함입니다.

- 자동 로그인 발생 문제 방지
- 비활성(제재) 사용자 로그인 차단
- 토큰 검증 및 재발급 흐름 안정화
- 프론트에서 인증 상태를 명확하게 처리할 수 있도록 응답 구조 개선

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [ ] Domain(Entity)
- [x] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

### ✔ 테스트 시나리오
- OAuth2 로그인 성공 시 토큰 정상 발급 확인
- 로그인 취소 시 FailureHandler 정상 동작 확인
- 비활성 사용자 로그인 차단 확인
- access token 만료 후 refresh 정상 재발급 확인
- 인증 상태 API 응답 확인

---

## ⚠️ 참고 사항

- 인증 실패 / 토큰 만료 / 제재 사용자 처리 방식이 변경되어  
  프론트에서 분기 처리 필요
- 인증 상태 응답 구조 변경으로 `/api/auth/status` 사용 방식 확인 필요
- refresh token은 HttpOnly 쿠키 기반으로 동작

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료