### PR TITLE
[BE] feature: 신고 및 사용자 제재 시스템 구축

### DIFF
--- a/src/main/java/com/tripmoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/tripmoa/global/exception/ErrorCode.java
@@ -29,12 +29,13 @@ public enum ErrorCode {
 
 
     // ====== User 도메인 ======
-
-    // 존재하지 않는 User 조회 시
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_001", "userId에 해당하는 사용자가 없습니다."),
-
-    // 이메일 정보가 제공되지 않은 경우
+    USER_FORBIDDEN(HttpStatus.FORBIDDEN, "USER_403_001", "접근할 수 없는 사용자입니다."),
+    BIRTH_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_001", "생년월일 등록 후 이용할 수 있습니다."),
+    ADULT_VERIFICATION_REQUIRED(HttpStatus.FORBIDDEN, "USER_403_002", "성인 인증 후 이용할 수 있습니다."),
+    UNDERAGE_USER(HttpStatus.FORBIDDEN, "USER_403_003", "미성년자는 이용할 수 없습니다."),
     OAUTH_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_400_001", "이메일 정보 제공 동의가 필요합니다."),
+    USER_SANCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_002", "사용자의 제재 정보를 찾을 수 없습니다."),
 
 
     // ====== Trip 도메인 ======
@@ -62,8 +63,6 @@ public enum ErrorCode {
 
 
     // ====== Expense 도메인 ======
-
-    // 존재하지 않는 Expense 조회 시
     EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXPENSE_404_001", "expenseId에 해당하는 영수증이 없습니다."),
 
 
@@ -163,6 +162,9 @@ public enum ErrorCode {
     CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST, "REPORT_400_001", "자기 자신은 신고할 수 없습니다."),
     ALREADY_REPORTED(HttpStatus.CONFLICT, "REPORT_409_001", "이미 신고한 대상입니다."),
     REPORTED_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_404_001", "신고 대상 사용자를 찾을 수 없습니다."),
+    ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "USER_403_003", "신고 정책으로 정지된 계정입니다."),
+    INVALID_REPORT_TARGET(HttpStatus.BAD_REQUEST, "REPORT_400_002", "신고 대상 정보가 올바르지 않습니다."),
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_404_002", "신고 대상 메시지를 찾을 수 없습니다."),
 
     // ====== 서버 내부 오류 ======
 

--- a/src/main/java/com/tripmoa/report/ContentStatus.java
+++ b/src/main/java/com/tripmoa/report/ContentStatus.java
@@ -1,0 +1,7 @@
+package com.tripmoa.report;
+
+// 콘텐츠 상태
+public enum ContentStatus {
+    NORMAL,      // 정상
+    REPORTED     // 신고 3회 이상
+}

--- a/src/main/java/com/tripmoa/report/ReportController.java
+++ b/src/main/java/com/tripmoa/report/ReportController.java
@@ -1,15 +1,17 @@
 package com.tripmoa.report;
 
+import com.tripmoa.report.dto.MyHiddenTargetsResponse;
+import com.tripmoa.report.dto.MyReportHistoryResponse;
+import com.tripmoa.report.dto.ReportRequest;
 import com.tripmoa.security.principal.CustomUserDetails;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Report", description = "신고 관련 API")
 @RestController
 @RequestMapping("/api/reports")
 @RequiredArgsConstructor
@@ -25,4 +27,32 @@ public class ReportController {
         reportService.report(userDetails.getUser().getId(), request);
         return ResponseEntity.ok().build();
     }
+
+    // 신고 내역 조회
+    @GetMapping("/me")
+    public ResponseEntity<MyReportHistoryResponse> getMyReportHistory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size) {
+
+        MyReportHistoryResponse response =
+                reportService.getMyReportHistory(userDetails.getUser().getId(), page, size);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 1단계용: 로그인한 사용자가 신고해서 내 화면에서 숨겨야 하는 대상 목록 조회
+     */
+    @GetMapping("/me/hidden-targets")
+    public ResponseEntity<MyHiddenTargetsResponse> getMyHiddenTargets(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam ReportLocation location
+    ) {
+        MyHiddenTargetsResponse response =
+                reportService.getMyHiddenTargets(userDetails.getUser().getId(), location);
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/tripmoa/report/ReportLocation.java
+++ b/src/main/java/com/tripmoa/report/ReportLocation.java
@@ -3,6 +3,6 @@ package com.tripmoa.report;
 // 신고 위치
 public enum ReportLocation {
 
-    COMMENT, CHAT, POST, MATE
+    COMMENT, CHAT
 
 }

--- a/src/main/java/com/tripmoa/report/ReportRepository.java
+++ b/src/main/java/com/tripmoa/report/ReportRepository.java
@@ -1,9 +1,44 @@
 package com.tripmoa.report;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ReportRepository extends JpaRepository<UserReport, Long> {
 
     // 같은 사람이 같은 대상을 이미 신고했는지 (중복 신고 방지)
-    boolean existsByReporterIdAndLocationAndTargetId(Long reporterId, ReportLocation location, Long targetId);
+    boolean existsByReporterIdAndLocationAndTargetId(
+            Long reporterId,
+            ReportLocation location,
+            Long targetId
+    );
+
+    // 페이징 신고 내역 조회
+    Page<UserReport> findAllByReportedUserIdOrderByReportedAtDesc(
+            Long reportedUserId,
+            Pageable pageable
+    );
+
+    // 특정 사용자가 신고당한 전체 내역 최신순 조회
+    List<UserReport> findAllByReportedUserIdOrderByReportedAtDesc(Long reportedUserId);
+
+    // 특정 사용자가 신고당한 총 횟수 조회
+    long countByReportedUserId(Long reportedUserId);
+
+    // 특정 위치의 특정 대상이 신고당한 횟수 조회
+    long countByLocationAndTargetId(ReportLocation location, Long targetId);
+
+    // 로그인한 사용자가 직접 신고한 대상 ID 목록 조회
+    @Query("""
+            select distinct r.targetId
+            from UserReport r
+            where r.reporter.id = :reporterId
+              and r.location = :location
+            order by r.targetId desc
+            """)
+    List<Long> findDistinctTargetIdsByReporterIdAndLocation(Long reporterId, ReportLocation location);
+
 }

--- a/src/main/java/com/tripmoa/report/ReportService.java
+++ b/src/main/java/com/tripmoa/report/ReportService.java
@@ -1,12 +1,27 @@
 package com.tripmoa.report;
 
+import com.tripmoa.chat.domain.ChatMessage;
+import com.tripmoa.chat.repository.ChatMessageRepository;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.report.dto.MyHiddenTargetsResponse;
+import com.tripmoa.report.dto.MyReportHistoryResponse;
+import com.tripmoa.report.dto.MyReportItemResponse;
+import com.tripmoa.report.dto.ReportRequest;
+import com.tripmoa.story.domain.StoryComment;
+import com.tripmoa.story.repository.StoryCommentRepository;
 import com.tripmoa.user.entity.User;
 import com.tripmoa.user.repository.UserRepository;
+import com.tripmoa.user.service.UserSanctionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,7 +29,9 @@ public class ReportService {
 
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
-    private static final int SNAPSHOT_MAX_LENGTH = 200;
+    private final UserSanctionService userSanctionService;
+    private final ChatMessageRepository chatMessageRepository;
+    private final StoryCommentRepository commentRepository;
 
     @Transactional
     public void report(Long reporterId, ReportRequest request) {
@@ -24,8 +41,31 @@ public class ReportService {
         }
 
         // 중복 신고 방지
-        boolean alreadyReported = reportRepository
-                .existsByReporterIdAndLocationAndTargetId(reporterId, request.getLocation(), request.getTargetId());
+        boolean alreadyReported = reportRepository.existsByReporterIdAndLocationAndTargetId(
+                reporterId,
+                request.getLocation(),
+                request.getTargetId()
+        );
+
+        // 댓글 실제 작성자를 조회 & 검증
+        if (request.getLocation() == ReportLocation.COMMENT) {
+            StoryComment comment = commentRepository.findById(request.getTargetId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+
+            if (!comment.getAuthor().getId().equals(request.getReportedUserId())) {
+                throw new BusinessException(ErrorCode.INVALID_REPORT_TARGET);
+            }
+        }
+
+        // 채팅 메세지 실제 작성자를 조회 & 검증
+        if (request.getLocation() == ReportLocation.CHAT) {
+            ChatMessage message = chatMessageRepository.findById(request.getTargetId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.MESSAGE_NOT_FOUND));
+
+            if (!message.getSender().getId().equals(request.getReportedUserId())) {
+                throw new BusinessException(ErrorCode.INVALID_REPORT_TARGET);
+            }
+        }
 
         if (alreadyReported) {
             throw new BusinessException(ErrorCode.ALREADY_REPORTED);
@@ -40,21 +80,111 @@ public class ReportService {
         UserReport report = UserReport.builder()
                 .reporter(reporter)
                 .reportedUser(reportedUser)
-                .reportedNickname(request.getReportedNickname())
+                .reportedNickname(reportedUser.getNickname())
                 .location(request.getLocation())
                 .targetId(request.getTargetId())
                 .reason(request.getReason())
                 .detail(request.getDetail())
-                .contentSnapshot(truncate(request.getContentSnapshot()))
                 .build();
 
-        reportRepository.save(report);
+        try {
+            reportRepository.save(report);
+            userSanctionService.applySanction(reportedUser.getId());
+        } catch (DataIntegrityViolationException e) {
+            // 동시 요청 등으로 DB 유니크 제약에 걸린 경우도 중복 신고로 처리
+            throw new BusinessException(ErrorCode.ALREADY_REPORTED);
+        }
     }
 
-    private String truncate(String text) {
-        if (text == null) return null;
-        if (text.length() <= SNAPSHOT_MAX_LENGTH) return text;
-        return text.substring(0, SNAPSHOT_MAX_LENGTH) + "...";
+    @Transactional(readOnly = true)
+    public MyReportHistoryResponse getMyReportHistory(Long userId, int page, int size) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        int safePage = Math.max(page, 0);
+        int safeSize = size <= 0 ? 5 : Math.min(size, 20);
+
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        Page<UserReport> reportPage = reportRepository
+                .findAllByReportedUserIdOrderByReportedAtDesc(userId, pageable);
+
+        long totalReportCount = reportPage.getTotalElements();
+        int currentLevel = resolveLevel(totalReportCount);
+        String currentLevelLabel = resolveLevelLabel(currentLevel);
+
+        List<MyReportItemResponse> items = reportPage.getContent().stream()
+                .map(report -> new MyReportItemResponse(
+                        report.getId(),
+                        report.getLocation().name(),
+                        report.getTargetId(),
+                        report.getReason(),
+                        report.getDetail(),
+                        report.getReportedNickname(),
+                        report.getReportedAt()
+                ))
+                .toList();
+
+        return new MyReportHistoryResponse(
+                currentLevel,
+                currentLevelLabel,
+                totalReportCount,
+                reportPage.getNumber(),
+                reportPage.getTotalPages(),
+                reportPage.getTotalElements(),
+                reportPage.getSize(),
+                items
+        );
     }
+
+    // 로그인한 사용자가 직접 신고한 대상 ID 목록 조회
+    @Transactional(readOnly = true)
+    public MyHiddenTargetsResponse getMyHiddenTargets(Long reporterId, ReportLocation location) {
+        userRepository.findById(reporterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        List<Long> targetIds = reportRepository
+                .findDistinctTargetIdsByReporterIdAndLocation(reporterId, location);
+
+        return new MyHiddenTargetsResponse(location.name(), targetIds);
+    }
+
+    @Transactional(readOnly = true)
+    public ContentStatus resolveContentStatus(ReportLocation location, Long targetId) {
+        long reportCount = reportRepository.countByLocationAndTargetId(location, targetId);
+        return reportCount >= 3 ? ContentStatus.REPORTED : ContentStatus.NORMAL;
+    }
+
+    @Transactional(readOnly = true)
+    public String resolveDisplayContent(ContentStatus status, String originalContent) {
+        return status == ContentStatus.REPORTED
+                ? "신고된 메시지입니다."
+                : originalContent;
+    }
+
+    @Transactional(readOnly = true)
+    public String resolveWriterName(ContentStatus status, String originalName) {
+        return status == ContentStatus.REPORTED
+                ? "작성자 미상"
+                : originalName;
+    }
+
+    private int resolveLevel(long totalReportCount) {
+        if (totalReportCount >= 15) return 4;
+        if (totalReportCount >= 10) return 3;
+        if (totalReportCount >= 5) return 2;
+        if (totalReportCount >= 1) return 1;
+        return 0;
+    }
+
+    private String resolveLevelLabel(int level) {
+        return switch (level) {
+            case 1 -> "1단계";
+            case 2 -> "2단계";
+            case 3 -> "3단계";
+            case 4 -> "4단계";
+            default -> "정상";
+        };
+    }
+
 }
-

--- a/src/main/java/com/tripmoa/report/UserReport.java
+++ b/src/main/java/com/tripmoa/report/UserReport.java
@@ -5,11 +5,25 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user_reports")
+@Table(
+        name = "user_reports",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_user_reports_report_once",
+                        columnNames = {"reporter_id", "location", "target_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_user_reports_reported_user_id", columnList = "reported_user_id"),
+                @Index(name = "idx_user_reports_target", columnList = "location, target_id"),
+                @Index(name = "idx_user_reports_reported_at", columnList = "reported_at")
+        }
+)
 @Getter
 @NoArgsConstructor
 public class UserReport {
@@ -28,39 +42,36 @@ public class UserReport {
     @JoinColumn(name = "reported_user_id", nullable = false)
     private User reportedUser;
 
-    // 신고당한 사람 닉네임 (탈퇴 대비)
-    @Column(length = 50)
+    // 신고 당시 닉네임 (닉변/탈퇴 대비)
+    @Column(name = "reported_nickname", length = 50)
     private String reportedNickname;
 
-    // 신고 위치 (POST, COMMENT, CHAT, MATE)
+    // 신고 위치
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private ReportLocation location;
 
-    // 대상 ID (chatRoomId, postId, commentId)
-    @Column(nullable = false)
+    // 신고 대상 ID
+    @Column(name = "target_id", nullable = false)
     private Long targetId;
 
-    // 신고 사유 (라디오 선택값)
-    @Column(nullable = false)
+    // 신고 사유
+    @Column(nullable = false, length = 100)
     private String reason;
 
-    // 추가 설명 (선택)
+    // 추가 설명
     @Column(length = 500)
     private String detail;
 
-    @Column(nullable = false)
+    // 신고 시각
+    @CreationTimestamp
+    @Column(name = "reported_at", nullable = false, updatable = false)
     private LocalDateTime reportedAt;
-
-    // 스냅샷 방식
-    @Column(length = 1000)
-    private String contentSnapshot;
 
     @Builder
     public UserReport(User reporter, User reportedUser, String reportedNickname,
-                      ReportLocation location,
-                      Long targetId, String reason, String detail,
-                      String contentSnapshot) {
+                      ReportLocation location, Long targetId, String reason,
+                      String detail) {
         this.reporter = reporter;
         this.reportedUser = reportedUser;
         this.reportedNickname = reportedNickname;
@@ -68,7 +79,5 @@ public class UserReport {
         this.targetId = targetId;
         this.reason = reason;
         this.detail = detail;
-        this.contentSnapshot = contentSnapshot;
-        this.reportedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/tripmoa/report/dto/MyHiddenTargetsResponse.java
+++ b/src/main/java/com/tripmoa/report/dto/MyHiddenTargetsResponse.java
@@ -1,0 +1,9 @@
+package com.tripmoa.report.dto;
+
+import java.util.List;
+
+public record MyHiddenTargetsResponse(
+        String location,
+        List<Long> targetIds
+) {
+}

--- a/src/main/java/com/tripmoa/report/dto/MyReportHistoryResponse.java
+++ b/src/main/java/com/tripmoa/report/dto/MyReportHistoryResponse.java
@@ -1,0 +1,17 @@
+package com.tripmoa.report.dto;
+
+import java.util.List;
+
+public record MyReportHistoryResponse(
+        int currentLevel,
+        String currentLevelLabel,
+        long totalReportCount,
+
+        int currentPage,
+        int totalPages,
+        long totalElements,
+        int pageSize,
+
+        List<MyReportItemResponse> reports
+) {
+}

--- a/src/main/java/com/tripmoa/report/dto/MyReportItemResponse.java
+++ b/src/main/java/com/tripmoa/report/dto/MyReportItemResponse.java
@@ -1,0 +1,14 @@
+package com.tripmoa.report.dto;
+
+import java.time.LocalDateTime;
+
+public record MyReportItemResponse(
+        Long reportId,
+        String location,
+        Long targetId,
+        String reason,
+        String detail,
+        String reportedNickname,
+        LocalDateTime reportedAt
+) {
+}

--- a/src/main/java/com/tripmoa/report/dto/ReportRequest.java
+++ b/src/main/java/com/tripmoa/report/dto/ReportRequest.java
@@ -1,5 +1,6 @@
-package com.tripmoa.report;
+package com.tripmoa.report.dto;
 
+import com.tripmoa.report.ReportLocation;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -22,6 +23,4 @@ public class ReportRequest {
     private String reason;
 
     private String detail;
-    private String contentSnapshot;
-    private String reportedNickname;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #100

---

## 🛠️ 작업 내용 (What)

신고 및 사용자 제재 시스템을 구현하고 관련 구조를 정리했습니다.

### ✔ 기능 구현
- 신고 생성 API 구현
- 신고 대상(댓글/채팅) 작성자 검증 로직 추가
- 동일 대상 중복 신고 방지 처리
- 신고 누적 기준 콘텐츠 숨김 처리 로직 구현
- 신고자 기준 숨김 대상 목록 조회 기능 구현
- 신고 내역 조회 API 추가
- ContentStatus 응답 객체 추가 (콘텐츠 상태 표현)

### ✔ 구조 및 정책 정리
- UserReport 스키마 수정 및 신고 시간 컬럼 추가
- ReportLocation 범위 축소 (COMMENT, CHAT)

---

## 🧭 작업 목적 (Why)

서비스 내 부적절한 콘텐츠를 관리하고 사용자 보호를 강화하기 위함입니다.

- 신고 누적 기반 자동 콘텐츠 필터링 적용
- 사용자 단위 제재 시스템 기반 구축
- 신고자 개인 화면에서 콘텐츠 제어 기능 제공
- 프론트에서 상태 기반 UI 처리가 가능하도록 응답 구조 개선

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [x] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

### ✔ 테스트 시나리오
- 신고 생성 시 정상 저장 여부 확인
- 동일 대상 중복 신고 차단 확인
- 자기 자신 신고 방지 확인
- 신고 3회 이상 누적 시 콘텐츠 숨김 처리 확인
- 신고자 기준 숨김 대상 조회 정상 동작 확인
- 신고 내역 조회 API 응답 확인

---

## ⚠️ 참고 사항

- 콘텐츠 상태는 `ContentStatus`를 통해 관리되며  
  일정 신고 누적 시 "신고된 메시지입니다"로 치환됨
- 작성자 정보는 신고 기준에 따라 익명 처리될 수 있음
- 프론트에서 숨김 처리 및 상태 분기 대응 필요

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료