### PR TITLE
[BE] feature: 사용자 제재 상태 관리 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/tripmoa/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/tripmoa/security/oauth/CustomOAuth2UserService.java
@@ -4,12 +4,11 @@ import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.user.entity.SocialAccount;
 import com.tripmoa.user.entity.User;
-import com.tripmoa.user.enums.Gender;
-import com.tripmoa.user.enums.ProfileType;
-import com.tripmoa.user.enums.Provider;
-import com.tripmoa.user.enums.UserStatus;
+import com.tripmoa.user.entity.UserSanction;
+import com.tripmoa.user.enums.*;
 import com.tripmoa.user.repository.SocialAccountRepository;
 import com.tripmoa.user.repository.UserRepository;
+import com.tripmoa.user.repository.UserSanctionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -31,6 +30,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
     private final SocialAccountRepository socialAccountRepository;
+    private final UserSanctionRepository userSanctionRepository;
 
     // 소셜 로그인 성공 시 자동 호출되는 메서드
     @Override
@@ -122,6 +122,14 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         // DB 저장
         User savedUser = userRepository.save(user);
+
+        UserSanction sanction = new UserSanction();
+        sanction.setUser(savedUser);
+        sanction.setLevel(0);
+        sanction.setTotalReports(0);
+        sanction.setStatus(SanctionStatus.NORMAL);
+
+        userSanctionRepository.save(sanction);
 
         // 소셜 계정 연결 정보 저장
         SocialAccount social = new SocialAccount();

--- a/src/main/java/com/tripmoa/user/controller/UserSanctionController.java
+++ b/src/main/java/com/tripmoa/user/controller/UserSanctionController.java
@@ -1,0 +1,37 @@
+package com.tripmoa.user.controller;
+
+import com.tripmoa.user.dto.MySanctionStatusResponse;
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.user.service.UserSanctionService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "UserSanction", description = "사용자 제재 상태 API")
+@RestController
+@RequestMapping("/api/users/me/sanction")
+@RequiredArgsConstructor
+public class UserSanctionController {
+
+    private final UserSanctionService userSanctionService;
+
+    @GetMapping
+    public ResponseEntity<MySanctionStatusResponse> getMySanctionStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        MySanctionStatusResponse response =
+                userSanctionService.getMySanctionStatus(userDetails.getUser().getId());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/warning-popup/read")
+    public ResponseEntity<Void> markWarningPopupRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userSanctionService.markWarningPopupRead(userDetails.getUser().getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/tripmoa/user/dto/MySanctionStatusResponse.java
+++ b/src/main/java/com/tripmoa/user/dto/MySanctionStatusResponse.java
@@ -1,0 +1,10 @@
+package com.tripmoa.user.dto;
+
+public record MySanctionStatusResponse(
+        int level,
+        int totalReports,
+        String status,
+        boolean showWarningPopup,
+        String warningMessage
+) {
+}

--- a/src/main/java/com/tripmoa/user/entity/UserSanction.java
+++ b/src/main/java/com/tripmoa/user/entity/UserSanction.java
@@ -4,6 +4,12 @@ import com.tripmoa.user.enums.SanctionStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+// 제재 상태
 
 @Entity
 @Table(name = "user_sanctions")
@@ -11,20 +17,37 @@ import lombok.Setter;
 @Setter
 public class UserSanction {
 
-    // 제제 상태
-
     @Id
+    @Column(name = "user_id")
     private Long userId;
 
     @MapsId
-    @OneToOne
-    @JoinColumn(name = "user_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(nullable = false)
     private Integer level = 0;
+
+    @Column(name = "total_reports", nullable = false)
     private Integer totalReports = 0;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
     private SanctionStatus status = SanctionStatus.NORMAL;
 
+    @Column(name = "warning_popup_checked_at")
+    private LocalDateTime warningPopupCheckedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void markWarningPopupChecked() {
+        this.warningPopupCheckedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/tripmoa/user/repository/UserSanctionRepository.java
+++ b/src/main/java/com/tripmoa/user/repository/UserSanctionRepository.java
@@ -1,0 +1,8 @@
+package com.tripmoa.user.repository;
+
+import com.tripmoa.user.entity.UserSanction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSanctionRepository extends JpaRepository<UserSanction, Long> {
+
+}

--- a/src/main/java/com/tripmoa/user/service/UserSanctionService.java
+++ b/src/main/java/com/tripmoa/user/service/UserSanctionService.java
@@ -1,0 +1,154 @@
+package com.tripmoa.user.service;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.report.ReportRepository;
+import com.tripmoa.user.dto.MySanctionStatusResponse;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.entity.UserSanction;
+import com.tripmoa.user.enums.SanctionStatus;
+import com.tripmoa.user.enums.UserStatus;
+import com.tripmoa.user.repository.UserRepository;
+import com.tripmoa.user.repository.UserSanctionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserSanctionService {
+
+    private final ReportRepository reportRepository;
+    private final UserSanctionRepository sanctionRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 신고 발생 시 호출되는 메서드
+     */
+    @Transactional
+    public void applySanction(Long userId) {
+
+        // 현재까지 누적 신고 횟수 조회
+        long totalReports = reportRepository.countByReportedUserId(userId);
+
+        // 신고 횟수 → 단계 계산 → 상태(NORMAL / WARNING / SUSPENDED) 변환
+        int level = resolveLevel(totalReports);
+        SanctionStatus status = resolveStatus(level);
+
+        // 기존 제재 상태 조회 (없으면 생성)
+        UserSanction sanction = sanctionRepository.findById(userId)
+                .orElse(null);
+
+        if (sanction == null) {
+            sanction = create(userId);
+            sanctionRepository.save(sanction);
+        }
+
+        sanction.setTotalReports((int) totalReports);
+        sanction.setLevel(level);
+
+        // 상태가 변경된 경우에만 처리
+        if (!sanction.getStatus().equals(status)) {
+            sanction.setStatus(status);
+
+            // 4단계 → 유저 정지
+            if (status == SanctionStatus.SUSPENDED) {
+                User user = userRepository.findById(userId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+                user.setStatus(UserStatus.SUSPENDED);
+            }
+        }
+
+    }
+
+    /**
+     * 로그인한 사용자의 현재 제재 상태 조회
+     */
+    @Transactional
+    public MySanctionStatusResponse getMySanctionStatus(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        applySanction(userId);
+
+        UserSanction sanction = sanctionRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_SANCTION_NOT_FOUND));
+
+        boolean showWarningPopup = shouldShowWarningPopup(sanction);
+
+        String warningMessage = showWarningPopup
+                ? "신고가 누적되었습니다. 반복될 경우 서비스 이용이 제한될 수 있습니다."
+                : null;
+
+        return new MySanctionStatusResponse(
+                sanction.getLevel(),
+                sanction.getTotalReports(),
+                sanction.getStatus().name(),
+                showWarningPopup,
+                warningMessage
+        );
+    }
+
+    @Transactional
+    public void markWarningPopupRead(Long userId) {
+        UserSanction sanction = sanctionRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_SANCTION_NOT_FOUND));
+
+        sanction.markWarningPopupChecked();
+    }
+
+    /**
+     * user_sanctions 최초 생성
+     */
+    private UserSanction create(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        UserSanction sanction = new UserSanction();
+        sanction.setUser(user);
+        sanction.setLevel(0);
+        sanction.setTotalReports(0);
+        sanction.setStatus(SanctionStatus.NORMAL);
+
+        return sanction;
+    }
+
+    // 신고 횟수 → 제재 단계 변환
+    private int resolveLevel(long count) {
+        if (count >= 15) return 4;
+        if (count >= 10) return 3;
+        if (count >= 5) return 2;
+        if (count >= 1) return 1;
+        return 0;
+    }
+
+    // 단계 → 상태 변환
+    private SanctionStatus resolveStatus(int level) {
+        if (level >= 4) return SanctionStatus.SUSPENDED;
+        if (level >= 2) return SanctionStatus.WARNING;
+        return SanctionStatus.NORMAL;
+    }
+
+    // 경고 팝업 노출 여부 판단
+    private boolean shouldShowWarningPopup(UserSanction sanction) {
+        if (sanction.getLevel() < 3) {
+            return false;
+        }
+
+        if (sanction.getStatus() == SanctionStatus.SUSPENDED) {
+            return false;
+        }
+
+        LocalDateTime checkedAt = sanction.getWarningPopupCheckedAt();
+
+        if (checkedAt == null) {
+            return true;
+        }
+
+        return checkedAt.toLocalDate().isBefore(LocalDate.now());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #101

---

## 🛠️ 작업 내용 (What)

사용자 제재 상태 관리 및 조회 기능을 구현했습니다.

### ✔ 기능 구현
- UserSanction 제재 상태(status), 레벨(level), 총 신고 수 컬럼 관리
- 팝업 노출 시간(popupShownAt) 컬럼 추가
- 사용자 제재 상태 조회 API 구현
- 신고 누적 기준에 따른 제재 상태 업데이트 로직 구현
- 제재 상태에 따른 팝업 노출 여부 체크 로직 추가

### ✔ 구조 개선
- CustomOAuth2UserService에서 최초 로그인 시 UserSanction 초기화 처리

---

## 🧭 작업 목적 (Why)

신고 시스템과 연계된 사용자 제재 흐름을 완성하고,  
프론트에서 제재 상태 기반 UX를 처리할 수 있도록 하기 위함입니다.

- 신고 누적 → 사용자 제재 상태 반영
- 로그인 시 제재 여부 판단 가능
- 경고/정지 상태에 따른 사용자 안내(팝업) 지원
- 사용자 상태를 일관된 기준으로 관리

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [x] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

### ✔ 테스트 시나리오
- 최초 로그인 시 UserSanction 정상 생성 여부 확인
- 신고 누적 시 제재 상태 변경 (NORMAL → WARNING → SUSPENDED) 확인
- 제재 상태 조회 API 응답 확인
- 팝업 노출 조건 충족 시 정상 반환 여부 확인
- 정지(SUSPENDED) 사용자 로그인 제한 동작 확인

---

## ⚠️ 참고 사항

- 제재 상태는 신고 누적 기준에 따라 자동 업데이트됨
- 팝업 노출 여부는 `popupShownAt` 기준으로 제어됨
- 프론트에서 제재 상태 기반 UI (경고/차단/안내 페이지) 처리 필요
- OAuth2 로그인 시 제재 상태 초기화 로직이 포함되어 있음

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료