### PR TITLE
[BE] feature: 성인 인증 및 이용 제한 로직 추가

### DIFF
--- a/src/main/java/com/tripmoa/notice/controller/NoticeGroupController.java
+++ b/src/main/java/com/tripmoa/notice/controller/NoticeGroupController.java
@@ -5,6 +5,7 @@ import com.tripmoa.notice.dto.request.NoticeGroupCreateRequest;
 import com.tripmoa.notice.dto.request.NoticeGroupRenameRequest;
 import com.tripmoa.notice.dto.response.NoticeGroupResponse;
 import com.tripmoa.notice.service.NoticeGroupService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "NoticeGroup", description = "공지사항 그룹 관리 API")
 @RestController
 @RequestMapping("/api/trips/{tripId}/notice-groups")
 @RequiredArgsConstructor

--- a/src/main/java/com/tripmoa/notice/controller/NoticeItemController.java
+++ b/src/main/java/com/tripmoa/notice/controller/NoticeItemController.java
@@ -6,6 +6,7 @@ import com.tripmoa.notice.dto.request.NoticeItemUpdateRequest;
 import com.tripmoa.notice.dto.response.NoticeItemResponse;
 import com.tripmoa.notice.dto.response.NoticeTagResponse;
 import com.tripmoa.notice.service.NoticeItemService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "NoticeItem", description = "공지사항 메모 관리 API")
 @RestController
 @RequestMapping("/api/trips/{tripId}/notice-items")
 @RequiredArgsConstructor

--- a/src/main/java/com/tripmoa/trip/repository/TripMemberRepository.java
+++ b/src/main/java/com/tripmoa/trip/repository/TripMemberRepository.java
@@ -2,6 +2,9 @@ package com.tripmoa.trip.repository;
 
 import com.tripmoa.trip.entity.TripMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -27,5 +30,17 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
 
     // 여행 목록 조회 시 여행마다 멤버를 개별 조회하지 않고 한 번에 가져와 N+1 문제를 방지하기 위한 메서드
     List<TripMember> findAllByTrip_IdInOrderByTrip_IdAscSortOrderAsc(List<Long> tripIds);
+
+    // 회원 탈퇴 시, 해당 유저가 참여 중이던 모든 여행 멤버 닉네임을 익명 처리
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update TripMember tm
+           set tm.nickname = :nickname
+         where tm.user.id = :userId
+    """)
+    void updateNicknameByUserId(
+            @Param("userId") Long userId,
+            @Param("nickname") String nickname
+    );
 
 }

--- a/src/main/java/com/tripmoa/user/controller/UserController.java
+++ b/src/main/java/com/tripmoa/user/controller/UserController.java
@@ -1,10 +1,9 @@
 package com.tripmoa.user.controller;
 
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.security.principal.CustomUserDetails;
-import com.tripmoa.user.dto.CheckEmailRequest;
-import com.tripmoa.user.dto.CheckEmailResponse;
-import com.tripmoa.user.dto.UserResponseDto;
-import com.tripmoa.user.dto.UserUpdateRequestDto;
+import com.tripmoa.user.dto.*;
 import com.tripmoa.user.service.AuthService;
 import com.tripmoa.user.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -54,7 +53,11 @@ public class UserController {
 
     // 가입 확인 Post
     @PostMapping("/users/check-email")
-    public CheckEmailResponse checkEmail(@RequestBody CheckEmailRequest request) {
+    public CheckEmailResponse checkEmail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody CheckEmailRequest request
+    ) {
+        if (userDetails == null) throw new BusinessException(ErrorCode.UNAUTHORIZED);
         return userService.checkEmail(request.getEmail());
     }
 
@@ -62,6 +65,14 @@ public class UserController {
     @PatchMapping("/users/me") // 경로를 /nickname에서 /me로 변경 제안
     public void updateProfile(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody UserUpdateRequestDto request) {
         userService.updateUserInfo(userDetails.getUser().getId(), request);
+    }
+
+    // 성인 인증 Patch
+    @PatchMapping("/users/me/age-verification")
+    public AgeVerificationResponseDto verifyAdult(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return userService.verifyAdult(userDetails.getUser().getId());
     }
 
     // 회원 탈퇴 Delete

--- a/src/main/java/com/tripmoa/user/dto/AgeVerificationResponseDto.java
+++ b/src/main/java/com/tripmoa/user/dto/AgeVerificationResponseDto.java
@@ -1,0 +1,11 @@
+package com.tripmoa.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AgeVerificationResponseDto {
+    private boolean ageVerified;
+    private String ageVerificationStatus;
+}

--- a/src/main/java/com/tripmoa/user/dto/UserResponseDto.java
+++ b/src/main/java/com/tripmoa/user/dto/UserResponseDto.java
@@ -2,71 +2,93 @@ package com.tripmoa.user.dto;
 
 import com.tripmoa.user.entity.SocialAccount;
 import com.tripmoa.user.entity.User;
-import lombok.AllArgsConstructor;
+import com.tripmoa.user.enums.AgeVerificationStatus;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.Period;
+import java.util.Comparator;
 import java.util.List;
 
-// 내 정보 조회 응답 DTO
-
 @Getter
-@AllArgsConstructor
+@Builder
 public class UserResponseDto {
-    public Long id;
-    public String nickname;
-    public String name;
-    public String email;
-    public String provider;
-    public String notificationEmail;
-    public String gender;
-    public String mbti;
-    public String profileImage;
-    public String profileType;
-    public String avatarEmoji;
-    public String avatarColor;
-    public LocalDate birthDate;
 
-    // 잠금 상태 필드
-    public boolean nameLocked;
-    public boolean genderLocked;
-    public boolean birthLocked;
+    // ── 식별 ──────────────────────────────────────────
+    private Long id;
 
-    public List<String> travelStyles;
+    // ── 기본 정보 ──────────────────────────────────────
+    private String nickname;
+    private String name;
+    private String email;
+    private String notificationEmail;
+    private String gender;
+    private String birthDate;
+    private String mbti;
+
+    // ── 프로필 이미지 ──────────────────────────────────
+    private String profileImage;
+    private String profileType;
+    private String avatarEmoji;
+    private String avatarColor;
+
+    // ── 소셜 계정 ──────────────────────────────────────
+    private String provider;
+    private List<String> linkedProviders;
+
+    // ── 잠금 여부 ──────────────────────────────────────
+    private boolean nameLocked;
+    private boolean genderLocked;
+    private boolean birthLocked;
+
+    // ── 인증 ───────────────────────────────────────────
+    private boolean ageVerified;
+    private String ageVerificationStatus;
+
+    // ── 여행 스타일 ────────────────────────────────────
+    private List<String> travelStyles;
 
     public static UserResponseDto from(User user) {
+        List<SocialAccount> sorted = user.getSocialAccounts().stream()
+                .sorted(Comparator.comparingLong(SocialAccount::getId))
+                .toList();
 
-        // 현재 연결(connected = true)된 소셜 계정 중 첫 번째를 찾아 provider 이름을 가져옴
-        String providerName = user.getSocialAccounts().stream()
-                .filter(sa -> Boolean.TRUE.equals(sa.getConnected()))
+        String mainProvider = sorted.isEmpty()
+                ? null
+                : sorted.get(0).getProvider().name();
+
+        List<String> linkedProviders = sorted.stream()
+                .skip(1)
                 .map(sa -> sa.getProvider().name())
-                .findFirst()
-                .orElse(null);
+                .toList();
 
-        return new UserResponseDto(
-                user.getId(),
-                user.getNickname(),
-                user.getName(),
-                user.getEmail(),
-                providerName,
-                user.getNotificationEmail(),
-                user.getGender() != null ? user.getGender().name() : null,
-                user.getMbti(),
-                user.getProfileImage(),
-                user.getProfileType().name(),
-                user.getAvatarEmoji(),
-                user.getAvatarColor(),
-                user.getBirthDate(),
-
-                // 잠금 필드
-                user.isNameLocked(),
-                user.isGenderLocked(),
-                user.isBirthLocked(),
-
-                user.getTravelStyles().stream()
-                        .map(userStyle -> userStyle.getStyle().getName())
-                        .toList()
-        );
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .name(user.getName())
+                .email(user.getEmail())
+                .notificationEmail(user.getNotificationEmail())
+                .gender(user.getGender() != null ? user.getGender().name() : null)
+                .birthDate(user.getBirthDate() != null ? user.getBirthDate().toString() : null)
+                .mbti(user.getMbti())
+                .profileImage(user.getProfileImage())
+                .profileType(user.getProfileType() != null ? user.getProfileType().name() : null)
+                .avatarEmoji(user.getAvatarEmoji())
+                .avatarColor(user.getAvatarColor())
+                .provider(mainProvider)
+                .linkedProviders(linkedProviders)
+                .nameLocked(user.isNameLocked())
+                .genderLocked(user.isGenderLocked())
+                .birthLocked(user.isBirthLocked())
+                .ageVerified(Boolean.TRUE.equals(user.getAgeVerified()))
+                .ageVerificationStatus(user.getAgeVerificationStatus().name())
+                .travelStyles(
+                        user.getTravelStyles().stream()
+                                .map(us -> us.getStyle().getName())
+                                .toList()
+                )
+                .build();
     }
-}
 
+}

--- a/src/main/java/com/tripmoa/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/com/tripmoa/user/dto/UserUpdateRequestDto.java
@@ -8,17 +8,17 @@ import java.util.List;
 // 정보 수정 요청 DTO
 
 @Getter
-@Setter // 값 주입을 위해 필요할 수 있음
+@Setter
 public class UserUpdateRequestDto {
-    public String nickname;
-    public String name;
-    public String notificationEmail;
-    public String gender;
-    public String birthDate;
-    public String mbti;
-    public List<String> travelStyles;
-    public String profileImage;
-    public String profileType;
-    public String avatarEmoji;
-    public String avatarColor;
+    private String nickname;
+    private String name;
+    private String notificationEmail;
+    private String gender;
+    private String birthDate;
+    private String mbti;
+    private List<String> travelStyles;
+    private String profileImage;
+    private String profileType;
+    private String avatarEmoji;
+    private String avatarColor;
 }

--- a/src/main/java/com/tripmoa/user/entity/User.java
+++ b/src/main/java/com/tripmoa/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.tripmoa.user.entity;
 
 import com.tripmoa.style.UserStyle;
+import com.tripmoa.user.enums.AgeVerificationStatus;
 import com.tripmoa.user.enums.Gender;
 import com.tripmoa.user.enums.ProfileType;
 import com.tripmoa.user.enums.UserStatus;
@@ -12,6 +13,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,6 +70,7 @@ public class User {
     private String avatarEmoji;
     private String avatarColor;
 
+    @Column(nullable = false)
     private Boolean ageVerified = false;
 
     @Enumerated(EnumType.STRING)
@@ -81,8 +84,37 @@ public class User {
     private LocalDateTime updatedAt;
 
     // === 메서드 ===
-    private String resolveNickname(User user) {
-        return user.getName();
+    public void verifyAdult() {
+        this.ageVerified = true;
+    }
+
+    public void resetAgeVerification() {
+        this.ageVerified = false;
+    }
+
+    public boolean hasBirthDate() {
+        return this.birthDate != null;
+    }
+
+    public boolean isAdultByBirthDate() {
+        if (this.birthDate == null) {
+            return false;
+        }
+        return Period.between(this.birthDate, LocalDate.now()).getYears() >= 19;
+    }
+
+    public AgeVerificationStatus getAgeVerificationStatus() {
+        if (Boolean.TRUE.equals(this.ageVerified)) {
+            return AgeVerificationStatus.VERIFIED;
+        }
+
+        if (this.birthDate == null) {
+            return AgeVerificationStatus.UNVERIFIED;
+        }
+
+        return isAdultByBirthDate()
+                ? AgeVerificationStatus.UNVERIFIED
+                : AgeVerificationStatus.UNDERAGE;
     }
 }
 

--- a/src/main/java/com/tripmoa/user/enums/AgeVerificationStatus.java
+++ b/src/main/java/com/tripmoa/user/enums/AgeVerificationStatus.java
@@ -1,0 +1,8 @@
+package com.tripmoa.user.enums;
+
+// 성인 인증 상태
+public enum AgeVerificationStatus {
+    UNVERIFIED,     // 초기 상태
+    VERIFIED,       // 성인 확인
+    UNDERAGE        // 이용 제한
+}

--- a/src/main/java/com/tripmoa/user/repository/SocialAccountRepository.java
+++ b/src/main/java/com/tripmoa/user/repository/SocialAccountRepository.java
@@ -7,6 +7,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/tripmoa/user/service/UserGuardService.java
+++ b/src/main/java/com/tripmoa/user/service/UserGuardService.java
@@ -1,0 +1,68 @@
+package com.tripmoa.user.service;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.enums.UserStatus;
+import com.tripmoa.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserGuardService {
+
+    private final UserRepository userRepository;
+
+    // 사용자 존재 확인, 없으면 404
+    public User getUserOr404(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // 활성 사용자 확인, 아니면 접근 불가
+    public User getActiveUserOr403(Long userId) {
+        User user = getUserOr404(userId);
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.USER_FORBIDDEN);
+        }
+
+        return user;
+    }
+
+    // 생년월일 등록 여부 확인
+    public void assertBirthDateExists(Long userId) {
+        User user = getActiveUserOr403(userId);
+
+        if (user.getBirthDate() == null) {
+            throw new BusinessException(ErrorCode.BIRTH_DATE_REQUIRED);
+        }
+    }
+
+    // 성인 인증 여부 확인
+    public void assertAdultVerified(Long userId) {
+        User user = getActiveUserOr403(userId);
+
+        if (!Boolean.TRUE.equals(user.getAgeVerified())) {
+            throw new BusinessException(ErrorCode.ADULT_VERIFICATION_REQUIRED);
+        }
+    }
+
+    // 생년월일 등록 여부와 성인 인증 여부 확인이 함께 필요한 경우
+    public void assertAdultAccess(Long userId) {
+        User user = getActiveUserOr403(userId);
+
+        if (user.getBirthDate() == null) {
+            throw new BusinessException(ErrorCode.BIRTH_DATE_REQUIRED);
+        }
+
+        if (!user.isAdultByBirthDate()) {
+            throw new BusinessException(ErrorCode.UNDERAGE_USER);
+        }
+
+        if (!Boolean.TRUE.equals(user.getAgeVerified())) {
+            throw new BusinessException(ErrorCode.ADULT_VERIFICATION_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/com/tripmoa/user/service/UserService.java
+++ b/src/main/java/com/tripmoa/user/service/UserService.java
@@ -1,23 +1,31 @@
 package com.tripmoa.user.service;
 
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.style.Style;
 import com.tripmoa.style.StyleRepository;
 import com.tripmoa.style.UserStyle;
+import com.tripmoa.trip.repository.TripMemberRepository;
+import com.tripmoa.user.dto.AgeVerificationResponseDto;
 import com.tripmoa.user.dto.CheckEmailResponse;
 import com.tripmoa.user.dto.UserResponseDto;
 import com.tripmoa.user.dto.UserUpdateRequestDto;
+import com.tripmoa.user.entity.SocialAccount;
 import com.tripmoa.user.entity.User;
+import com.tripmoa.user.enums.AgeVerificationStatus;
 import com.tripmoa.user.enums.Gender;
 import com.tripmoa.user.enums.ProfileType;
 import com.tripmoa.user.enums.UserStatus;
 import com.tripmoa.user.repository.RefreshTokenRepository;
 import com.tripmoa.user.repository.SocialAccountRepository;
 import com.tripmoa.user.repository.UserRepository;
+import com.tripmoa.user.repository.UserSanctionRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
 
 // 사용자 관련 비즈니스 로직 담당 서비스
 
@@ -30,13 +38,12 @@ public class UserService {
     private final StyleRepository styleRepository;
     private final SocialAccountRepository socialAccountRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final UserGuardService userGuardService;
+    private final TripMemberRepository tripMemberRepository;
 
     // 내 정보 조회
     public UserResponseDto getMyInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("사용자 없음"));
-
-        // 수동으로 생성자를 호출하는 대신 from 메서드를 사용하면 관리가 편합니다.
+        User user = userGuardService.getActiveUserOr403(userId);
         return UserResponseDto.from(user);
     }
 
@@ -55,12 +62,14 @@ public class UserService {
                         .build());
     }
 
-    @Transactional
     public void updateUserInfo(Long userId, UserUpdateRequestDto dto) {
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userGuardService.getActiveUserOr403(userId);
 
         // 기본 정보 업데이트
-        user.setNickname(dto.getNickname());
+        if (dto.getNickname() != null && !dto.getNickname().isBlank()) {
+            user.setNickname(dto.getNickname());
+        }
+
         user.setNotificationEmail(dto.getNotificationEmail());
         user.setMbti(dto.getMbti());
 
@@ -79,8 +88,9 @@ public class UserService {
             try {
                 user.setBirthDate(LocalDate.parse(dto.getBirthDate()));
                 user.setBirthLocked(true);
+                user.resetAgeVerification();
             } catch (Exception e) {
-                throw new IllegalArgumentException("생년월일 형식이 올바르지 않습니다. (YYYY-MM-DD)");
+                throw new BusinessException(ErrorCode.INVALID_REQUEST);
             }
         }
 
@@ -90,25 +100,25 @@ public class UserService {
             user.setProfileType(targetType);
 
             if (targetType == ProfileType.CUSTOM) {
-                if (dto.getProfileImage() != null && !dto.getProfileImage().equals(user.getProfileImage())) {
-                    user.setProfileImage(dto.getProfileImage());
-                }
+                user.setProfileImage(dto.getProfileImage());
+                user.setAvatarEmoji(null);
+                user.setAvatarColor(null);
             } else if (targetType == ProfileType.AVATAR) {
-                if (dto.getAvatarEmoji() != null) user.setAvatarEmoji(dto.getAvatarEmoji());
-                if (dto.getAvatarColor() != null) user.setAvatarColor(dto.getAvatarColor());
+                user.setAvatarEmoji(dto.getAvatarEmoji());
+                user.setAvatarColor(dto.getAvatarColor());
                 user.setProfileImage(null);
             }
         }
 
-        // 기존 스타일 삭제
-        user.getTravelStyles().clear();
-        userRepository.saveAndFlush(user);
-
         // 비워진 상태에서 새로운 스타일 추가
         if (dto.getTravelStyles() != null) {
+            // 기존 스타일 삭제
+            user.getTravelStyles().clear();
+            userRepository.saveAndFlush(user);
+
             for (String styleName : dto.getTravelStyles()) {
                 Style style = styleRepository.findByName(styleName)
-                        .orElseThrow(() -> new RuntimeException("존재하지 않는 스타일: " + styleName));
+                        .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REQUEST));
 
                 UserStyle userStyle = new UserStyle();
                 userStyle.setUser(user);
@@ -118,11 +128,35 @@ public class UserService {
         }
     }
 
-    // 회원 탈퇴
+    // 성인 인증
     @Transactional
+    public AgeVerificationResponseDto verifyAdult(Long userId) {
+        User user = userGuardService.getActiveUserOr403(userId);
+
+        if (Boolean.TRUE.equals(user.getAgeVerified())) {
+            return new AgeVerificationResponseDto(true, AgeVerificationStatus.VERIFIED.name());
+        }
+
+        userGuardService.assertBirthDateExists(userId);
+
+        if (!user.isAdultByBirthDate()) {
+            return new AgeVerificationResponseDto(
+                    false,
+                    AgeVerificationStatus.UNDERAGE.name()
+            );
+        }
+
+        user.verifyAdult();
+
+        return new AgeVerificationResponseDto(
+                true,
+                AgeVerificationStatus.VERIFIED.name()
+        );
+    }
+
+    // 회원 탈퇴
     public void withdraw(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        User user = userGuardService.getActiveUserOr403(userId);
 
         // 리프레쉬 토큰 삭제 (보안 및 세션 만료)
         refreshTokenRepository.deleteByUser(user);
@@ -139,16 +173,19 @@ public class UserService {
         user.setStatus(UserStatus.WITHDRAWN);
 
         // 개인정보 익명화 (Null 처리 또는 마스킹)
-        user.setNickname("알수 없음"); // 화면 표시용
+        user.setNickname("알수 없음");      // 화면 표시용
+        tripMemberRepository.updateNicknameByUserId(userId, "알수 없음");
         user.setName(null);
-        user.setEmail(null); // 중복 가입 방지를 위해 필요한 경우 마스킹 처리 (예: wh***@mail.com)
+        user.setEmail(null);              // TODO : 중복 가입 방지를 위해 필요한 경우 마스킹 처리 (예: wh***@mail.com)
         user.setNotificationEmail(null);
         user.setGender(null);
         user.setBirthDate(null);
         user.setMbti(null);
         user.setProfileImage(null);
-        user.setAvatarEmoji(null);
-        user.setAvatarColor(null);
+        user.setProfileType(ProfileType.AVATAR);
+        user.setAvatarEmoji("👤");
+        user.setAvatarColor("#9CA3AF");
+        user.setAgeVerified(false);
 
         userRepository.save(user);
     }

--- a/src/main/java/com/tripmoa/voucher/controller/VoucherController.java
+++ b/src/main/java/com/tripmoa/voucher/controller/VoucherController.java
@@ -5,6 +5,7 @@ import com.tripmoa.voucher.dto.VoucherCreateRequest;
 import com.tripmoa.voucher.dto.VoucherUpdateRequest;
 import com.tripmoa.voucher.dto.VoucherResponse;
 import com.tripmoa.voucher.service.VoucherService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -15,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Tag(name = "Voucher", description = "바우처 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/trips/{tripId}/vouchers")


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #102

---

## 🛠️ 작업 내용 (What)

성인 인증 및 서비스 이용 제한 로직을 구현했습니다.

### ✔ 기능 구현
- AgeVerificationStatus enum 추가 (UNVERIFIED, UNDERAGE, VERIFIED)
- 사용자 성인 인증 API 구현
- 생년월일 기반 성인 여부 판단 로직 구현
- 성인 인증 상태에 따른 서비스 접근 제한 처리

### ✔ 접근 제어 로직 추가
- UserGuardService를 통한 사용자 접근 제어 로직 구현
  - 비로그인 사용자 접근 제한
  - 미성년자 서비스 이용 제한
  - 인증되지 않은 사용자 기능 접근 제어

---

## 🧭 작업 목적 (Why)

서비스를 성인 사용자 중심으로 운영하기 위한 접근 제어 시스템을 구축하기 위함입니다.

- 미성년자 이용 제한 정책 적용
- 인증 여부에 따른 기능 접근 제어
- 프론트에서 상태 기반 UX 처리 가능하도록 지원
- 인증/제재 시스템과 연계된 통합 사용자 상태 관리

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [ ] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

### ✔ 테스트 시나리오
- 성인 인증 API 호출 시 정상 응답 확인
- 생년월일 기준 성인/미성년자 판별 확인
- 미성년자 접근 제한 로직 동작 확인
- 인증되지 않은 사용자 접근 제어 확인
- 인증 상태 변경 후 정상 반영 여부 확인

---

## ⚠️ 참고 사항

- 성인 인증 상태는 `AgeVerificationStatus` 기준으로 관리됨
- UserGuardService를 통해 서비스 접근 제어가 수행됨
- 프론트에서 인증 상태에 따라
  - 이용 제한 안내
  - 인증 유도 UX 처리 필요

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료