### PR TITLE
[BE] feature: 여행 스타일 조회 API 및 초기 데이터 구성

### DIFF
--- a/src/main/java/com/tripmoa/style/StyleController.java
+++ b/src/main/java/com/tripmoa/style/StyleController.java
@@ -1,0 +1,24 @@
+package com.tripmoa.style;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class StyleController {
+
+    private final StyleRepository styleRepository;
+
+    @GetMapping("/styles")
+    public List<StyleDto> getStyles() {
+        return styleRepository.findAll()
+                .stream()
+                .map(style -> new StyleDto(style.getId(), style.getName()))
+                .toList();
+    }
+}

--- a/src/main/java/com/tripmoa/style/StyleDto.java
+++ b/src/main/java/com/tripmoa/style/StyleDto.java
@@ -1,0 +1,11 @@
+package com.tripmoa.style;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StyleDto {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/tripmoa/style/TravelStyleDataInitializer.java
+++ b/src/main/java/com/tripmoa/style/TravelStyleDataInitializer.java
@@ -1,0 +1,41 @@
+package com.tripmoa.style;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// 여행 스타일 자동 생성
+@Component
+@RequiredArgsConstructor
+public class TravelStyleDataInitializer implements CommandLineRunner {
+
+    private final StyleRepository styleRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        if (styleRepository.count() > 0) {
+            return;
+        }
+
+        List<String> styleNames = List.of(
+                "맛집탐방", "액티비티", "힐링", "문화탐방",
+                "쇼핑", "자연", "사진", "야경",
+                "로컬체험", "카페투어", "축제", "역사탐방",
+                "야외활동", "미식투어", "럭셔리", "배낭여행"
+        );
+
+        List<Style> styles = styleNames.stream()
+                .map(name -> {
+                    Style style = new Style();
+                    style.setName(name);
+                    return style;
+                })
+                .toList();
+
+        styleRepository.saveAll(styles);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #103

---

## 🛠️ 작업 내용 (What)

여행 스타일 조회 API 및 초기 데이터 세팅을 구현했습니다.

### ✔ 기능 구현
- StyleController 여행 스타일 조회 API 추가
- 사용자 여행 스타일 목록 조회 기능 구현

### ✔ 초기 데이터 구성
- TravelStyleDataInitializer를 통해 기본 여행 스타일 자동 생성
- 애플리케이션 실행 시 초기 데이터 세팅

---

## 🧭 작업 목적 (Why)

여행 스타일 데이터를 백엔드 기준으로 관리하고,  
프론트에서 하드코딩 없이 API 기반으로 사용할 수 있도록 하기 위함입니다.

- 여행 스타일 목록 관리 일원화
- 프론트 하드코딩 제거
- 초기 데이터 자동 세팅으로 운영 편의성 확보
- 사용자 프로필/설정 기능과의 연계 기반 마련

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

### ✔ 테스트 시나리오
- 서버 실행 시 기본 여행 스타일 데이터 자동 생성 확인
- 중복 실행 시 데이터 중복 생성 방지 확인
- 여행 스타일 조회 API 정상 응답 확인

---

## ⚠️ 참고 사항

- 여행 스타일 데이터는 애플리케이션 시작 시 자동으로 초기화됨
- 프론트에서는 기존 상수 대신 `/api/users/styles` API 사용 필요
- 데이터 변경 시 초기 데이터 로직도 함께 관리 필요

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료