### PR TITLE
[BE] refactor: 회원 탈퇴 시 소유 여행 처리 로직 개선

### DIFF
--- a/src/main/java/com/tripmoa/trip/entity/Trip.java
+++ b/src/main/java/com/tripmoa/trip/entity/Trip.java
@@ -109,6 +109,10 @@ public class Trip {
         member.setTrip(null);
     }
 
+    public void changeOwner(User newOwner) {
+        this.owner = newOwner;
+    }
+
     public void updateBasicInfo(String title, LocalDate tripStartDate, LocalDate tripEndDate) {
         this.title = title;
         this.tripStartDate = tripStartDate;

--- a/src/main/java/com/tripmoa/user/service/UserService.java
+++ b/src/main/java/com/tripmoa/user/service/UserService.java
@@ -5,7 +5,11 @@ import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.style.Style;
 import com.tripmoa.style.StyleRepository;
 import com.tripmoa.style.UserStyle;
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.entity.TripMember;
+import com.tripmoa.trip.enums.TripStatus;
 import com.tripmoa.trip.repository.TripMemberRepository;
+import com.tripmoa.trip.repository.TripRepository;
 import com.tripmoa.user.dto.AgeVerificationResponseDto;
 import com.tripmoa.user.dto.CheckEmailResponse;
 import com.tripmoa.user.dto.UserResponseDto;
@@ -39,6 +43,7 @@ public class UserService {
     private final SocialAccountRepository socialAccountRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserGuardService userGuardService;
+    private final TripRepository tripRepository;
     private final TripMemberRepository tripMemberRepository;
 
     // 내 정보 조회
@@ -157,6 +162,9 @@ public class UserService {
     // 회원 탈퇴
     public void withdraw(Long userId) {
         User user = userGuardService.getActiveUserOr403(userId);
+        
+        // 여행 계획 소유권 양도
+        handleOwnedTripsOnWithdraw(userId);
 
         // 리프레쉬 토큰 삭제 (보안 및 세션 만료)
         refreshTokenRepository.deleteByUser(user);
@@ -188,6 +196,28 @@ public class UserService {
         user.setAgeVerified(false);
 
         userRepository.save(user);
+    }
+
+    private void handleOwnedTripsOnWithdraw(Long userId) {
+        List<Trip> ownedTrips =
+                tripRepository.findAllByOwner_IdAndStatusOrderByCreatedAtDesc(userId, TripStatus.ACTIVE);
+
+        for (Trip trip : ownedTrips) {
+            List<TripMember> members =
+                    tripMemberRepository.findAllByTrip_IdOrderBySortOrderAsc(trip.getId());
+
+            TripMember nextOwner = members.stream()
+                    .filter(member -> member.getUser() != null)
+                    .filter(member -> !member.getUser().getId().equals(userId))
+                    .findFirst()
+                    .orElse(null);
+
+            if (nextOwner == null) {
+                trip.archive();
+            } else {
+                trip.changeOwner(nextOwner.getUser());
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #109

---

## 🛠️ 작업 내용 (What)
- 회원 탈퇴 시 소유한 여행 처리 로직 추가
- 소유 여행 조회 후 멤버 존재 여부에 따른 분기 처리
  - 남은 멤버가 있는 경우 → 가장 먼저 참여한 멤버에게 owner 이전
  - 남은 멤버가 없는 경우 → 여행 ARCHIVED 처리
- 기존 여행 삭제(deleteTrip) 로직은 변경 없이 유지

---

## 🧭 작업 목적 (Why)
회원 탈퇴 시 소유한 여행의 owner가 그대로 유지되어  
남아있는 멤버가 있는 경우에도 소유자 부재 상태가 발생하는 문제를 해결하기 위함

탈퇴 시점에 여행을 정리하여
데이터 정합성과 사용자 경험을 개선

---

## 🧩 변경 범위
- [ ] Controller
- [x] Service
- [x] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

### 테스트 케이스
1. 소유자가 혼자 있는 여행 탈퇴
   → 여행 ARCHIVED 처리 확인

2. 멤버가 있는 여행 탈퇴
   → owner가 다음 멤버로 정상 변경되는지 확인

3. 기존 여행 삭제 API
   → 여전히 owner만 ARCHIVED 처리 가능한지 확인

---

## ⚠️ 참고 사항
- 기존 탈퇴 로직(토큰 삭제, 소셜 계정 삭제, 개인정보 익명화)에는 영향 없음
- 여행 삭제 기능과 탈퇴 로직의 역할을 명확히 분리
- owner 이전 기준은 sortOrder 기준 첫 번째 멤버로 처리

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [ ] API 명세 변경 시 공유 완료