### PR TITLE
[BE] refactor: OCR 후처리 데이터 기반 LLM 자동분류 연동

### DIFF
--- a/src/main/java/com/tripmoa/ai/domain/AiClient.java
+++ b/src/main/java/com/tripmoa/ai/domain/AiClient.java
@@ -2,6 +2,8 @@ package com.tripmoa.ai.domain;
 
 import com.tripmoa.ai.dto.AiScheduleRequest;
 import com.tripmoa.ai.dto.AiScheduleResponse;
+import com.tripmoa.expense.dto.request.OcrLlmRequest;
+import com.tripmoa.expense.dto.response.OcrLlmResponse;
 import com.tripmoa.place.dto.PlaceSearchResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -41,4 +43,11 @@ public class AiClient {
                 .toUri();
         return restTemplate.getForObject(uri, PlaceSearchResponse.class);
     }
+
+    // OCR 영수증 LLM 분석
+    public OcrLlmResponse analyzeReceipt(OcrLlmRequest request) {
+        String url = aiServerUrl + "/ocr/analyze";
+        return restTemplate.postForObject(url, request, OcrLlmResponse.class);
+    }
+
 }

--- a/src/main/java/com/tripmoa/expense/controller/OcrController.java
+++ b/src/main/java/com/tripmoa/expense/controller/OcrController.java
@@ -2,10 +2,7 @@ package com.tripmoa.expense.controller;
 
 import com.tripmoa.expense.dto.request.OcrAutofillRequest;
 import com.tripmoa.expense.dto.response.OcrAutofillWithPreviewResponse;
-import com.tripmoa.expense.dto.response.OcrInitialResponse;
-import com.tripmoa.expense.service.OcrMapper;
 import com.tripmoa.expense.service.OcrService;
-import com.tripmoa.trip.service.TripPermissionService;
 import com.tripmoa.security.principal.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,35 +26,10 @@ import java.util.Map;
 public class OcrController {
 
     private final OcrService ocrService;
-    private final OcrMapper ocrMapper;
-    private final TripPermissionService tripPermissionService;
 
     /**
-     * OCR 자동채움 (프론트용)
-     * - tripId 기반 권한 체크(여행 멤버 여부 등) 후 OCR 호출
-     * - Swagger 파일 파라미터
-     */
-    @PostMapping(value="/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<OcrInitialResponse> ocrAutofill(
-            @PathVariable Long tripId,
-            @RequestParam("file") MultipartFile file,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        Long userId = userDetails.getUser().getId();
-
-        ocrService.validateFile(file);
-        tripPermissionService.assertOwnerOrMember(tripId, userId);
-
-        Map<String, Object> raw = ocrService.callOcrApi(file);
-        OcrInitialResponse dto = ocrMapper.toAutofillResponse(raw);
-
-        return ResponseEntity.ok(dto);
-    }
-
-    /**
-     * OCR 자동채움 Test
-     * - OCR 결과로 자동채움 데이터를 만들고
-     * - 현재 모달 입력값 기준으로 첫 split preview도 함께 반환
+     * OCR 자동채움
+     * - OCR 결과로 자동채움 + 데이터 후처리 + LLM 연결
      */
     @Operation(summary = "OCR + preview 테스트")
     @RequestBody(
@@ -66,8 +38,8 @@ public class OcrController {
                     encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)
             )
     )
-    @PostMapping(value = "/ocr/test", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<OcrAutofillWithPreviewResponse> ocrAutofillTest(
+    @PostMapping(value = "/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<OcrAutofillWithPreviewResponse> ocrAutofill(
             @PathVariable Long tripId,
             @RequestPart("file") MultipartFile file,
             @RequestPart("request") @Valid OcrAutofillRequest request,

--- a/src/main/java/com/tripmoa/expense/dto/request/OcrAiAutofillResult.java
+++ b/src/main/java/com/tripmoa/expense/dto/request/OcrAiAutofillResult.java
@@ -1,0 +1,8 @@
+package com.tripmoa.expense.dto.request;
+
+import com.tripmoa.expense.enums.ExpenseCategory;
+
+public record OcrAiAutofillResult(
+        String itemMemo,
+        ExpenseCategory category
+) {}

--- a/src/main/java/com/tripmoa/expense/service/OcrAiAutofillService.java
+++ b/src/main/java/com/tripmoa/expense/service/OcrAiAutofillService.java
@@ -1,0 +1,64 @@
+package com.tripmoa.expense.service;
+
+import com.tripmoa.ai.domain.AiClient;
+import com.tripmoa.expense.dto.request.OcrAiAutofillResult;
+import com.tripmoa.expense.dto.request.OcrLlmRequest;
+import com.tripmoa.expense.dto.response.OcrInitialResponse;
+import com.tripmoa.expense.dto.response.OcrLlmResponse;
+import com.tripmoa.expense.enums.ExpenseCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OcrAiAutofillService {
+
+    private final AiClient aiClient;
+
+    // LLM 연결
+    public OcrAiAutofillResult guessItemAndCategory(OcrInitialResponse base) {
+        try {
+            OcrLlmRequest request = new OcrLlmRequest(
+                    base.storeName(),
+                    base.menuName(),
+                    base.paymentMethod(),
+                    base.dateTime(),
+                    base.totalAmount()
+            );
+
+            OcrLlmResponse response = aiClient.analyzeReceipt(request);
+
+            if (response == null) {
+                return fallback(base);
+            }
+
+            return new OcrAiAutofillResult(
+                    safeItemMemo(response.itemMemo(), base),
+                    response.category() == null ? ExpenseCategory.ETC : response.category()
+            );
+
+        } catch (Exception e) {
+            return fallback(base);
+        }
+    }
+
+    private OcrAiAutofillResult fallback(OcrInitialResponse base) {
+        if (base.menuName() == null || base.menuName().isBlank()) {
+            return new OcrAiAutofillResult("기타 지출", ExpenseCategory.ETC);
+        }
+
+        return new OcrAiAutofillResult(base.menuName(), ExpenseCategory.ETC);
+    }
+
+    private String safeItemMemo(String itemMemo, OcrInitialResponse base) {
+        if (itemMemo != null && !itemMemo.isBlank()) {
+            return itemMemo;
+        }
+
+        if (base.menuName() != null && !base.menuName().isBlank()) {
+            return base.menuName();
+        }
+
+        return "기타 지출";
+    }
+}

--- a/src/main/java/com/tripmoa/expense/service/OcrMapper.java
+++ b/src/main/java/com/tripmoa/expense/service/OcrMapper.java
@@ -2,9 +2,9 @@ package com.tripmoa.expense.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tripmoa.expense.dto.request.OcrAiAutofillResult;
 import com.tripmoa.expense.dto.response.OcrAutofillResponse;
 import com.tripmoa.expense.dto.response.OcrInitialResponse;
-import com.tripmoa.expense.enums.ExpenseCategory;
 import com.tripmoa.expense.enums.PayMethod;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +17,22 @@ public class OcrMapper {
 
     private final ObjectMapper objectMapper;
 
+    // OCR 후처리 데이터 + LLM 판단 결과를 최종 자동채움 응답으로 조립
+    public OcrAutofillResponse toAutofillResponse(
+            OcrInitialResponse base,
+            OcrAiAutofillResult aiResult
+    ) {
+        return new OcrAutofillResponse(
+                base.storeName(),
+                aiResult.itemMemo(),
+                aiResult.category(),
+                PayMethod.fromText(base.paymentMethod()),
+                base.dateTime(),
+                base.totalAmount()
+        );
+    }
+
+    // 데이터 후처리 가공
     public OcrInitialResponse toAutofillResponse(Map<String, Object> ocrRaw) {
         JsonNode root = objectMapper.valueToTree(ocrRaw);
 
@@ -88,20 +104,6 @@ public class OcrMapper {
         } catch (NumberFormatException e) {
             return null;
         }
-    }
-
-    // 임시 자동채움
-    public OcrAutofillResponse toAutofillResult(Map<String, Object> ocrRaw) {
-        OcrInitialResponse base = toAutofillResponse(ocrRaw);
-
-        return new OcrAutofillResponse(
-                base.storeName(),
-                base.menuName(),                       // menuName → itemMemo
-                ExpenseCategory.ETC,                   // 고정
-                PayMethod.fromText(base.paymentMethod()),
-                base.dateTime(),                       // dateTime → paidAt
-                base.totalAmount()
-        );
     }
 
 }

--- a/src/main/java/com/tripmoa/expense/service/OcrService.java
+++ b/src/main/java/com/tripmoa/expense/service/OcrService.java
@@ -1,10 +1,12 @@
 package com.tripmoa.expense.service;
 
 import com.tripmoa.expense.dto.request.ExpensePreviewRequest;
+import com.tripmoa.expense.dto.request.OcrAiAutofillResult;
 import com.tripmoa.expense.dto.request.OcrAutofillRequest;
 import com.tripmoa.expense.dto.response.ExpensePreviewResponse;
 import com.tripmoa.expense.dto.response.OcrAutofillResponse;
 import com.tripmoa.expense.dto.response.OcrAutofillWithPreviewResponse;
+import com.tripmoa.expense.dto.response.OcrInitialResponse;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
 import com.tripmoa.trip.service.TripPermissionService;
@@ -55,6 +57,7 @@ public class OcrService {
     private final TripPermissionService tripPermissionService;
     private final OcrMapper ocrMapper;
     private final SettlementPreviewService settlementPreviewService;
+    private final OcrAiAutofillService ocrAiAutofillService;
 
     // 프록시 컨트롤러에서 먼저 호출할 파일 검증
     public void validateFile(MultipartFile file) {
@@ -87,7 +90,12 @@ public class OcrService {
         tripPermissionService.assertOwnerOrMember(tripId, userId);
 
         Map<String, Object> raw = callOcrApi(file);
-        OcrAutofillResponse autofill = ocrMapper.toAutofillResult(raw);
+
+        OcrInitialResponse base = ocrMapper.toAutofillResponse(raw);
+        OcrAiAutofillResult aiResult = ocrAiAutofillService.guessItemAndCategory(base);
+
+        OcrAutofillResponse autofill =
+                ocrMapper.toAutofillResponse(base, aiResult);
 
         Integer totalAmount = autofill.totalAmount();
         if (totalAmount == null || totalAmount <= 0) {
@@ -219,4 +227,5 @@ public class OcrService {
     private boolean isBlank(String s) {
         return s == null || s.trim().isEmpty();
     }
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #111

---

## 🛠️ 작업 내용 (What)

- OCR 후처리 데이터를 기반으로 Python AI 서버에 LLM 분석 요청을 보내는 흐름을 추가했습니다.
- OCR 원본 응답을 후처리한 뒤, LLM 분석 결과와 조합하여 최종 자동채움 응답을 생성하도록 개선했습니다.
- 기존 임시 매핑 기반 OCR 자동채움 로직을 LLM 기반 자동 분류 구조로 변경했습니다.
- OCR 자동채움 API 경로 구조를 정리하고 요청 흐름을 개선했습니다.
- LLM 응답 실패 시 fallback 자동채움 로직을 추가했습니다.

---

## 🧭 작업 목적 (Why)

기존 OCR 자동채움은 단순 임시 매핑 방식으로 동작하여 지출 메모 및 카테고리 분류 정확도에 한계가 있었습니다.

이를 개선하기 위해 OCR 후처리 데이터를 기반으로 Python AI 서버의 LLM 분석 결과를 활용하도록 구조를 변경하였으며, 
기존 preview 계산 흐름은 유지하면서 자동 분류 정확도를 개선하고자 했습니다.

또한 OCR API 요청 흐름과 경로 구조를 정리하여 유지보수성을 높였습니다.

---

## 🧩 변경 범위

- [x] Controller
- [x] Service
- [ ] Domain(Entity)
- [ ] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법

- [x] 로컬 서버 실행
- [x] OCR API 테스트 (Swagger)
- [x] OCR 후처리 → LLM 자동분류 응답 확인
- [x] LLM 실패 fallback 동작 확인
- [x] preview 계산 정상 동작 확인
- [x] 예외 케이스 확인

---

## ⚠️ 참고 사항

- Python AI 서버 `/ocr/analyze` 엔드포인트 연동이 필요합니다.
- LLM 응답 실패 또는 응답값 누락 시 fallback 자동채움 로직이 동작합니다.
- OCR 자동채움 응답은 OCR 후처리 데이터 + LLM 분석 결과를 조합하여 생성됩니다.

---

## ✅ 체크리스트

- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료