### PR TITLE
[BE] feature: 초대코드 기반 여행 조회 및 참여 기능 구현

### DIFF
--- a/src/main/java/com/tripmoa/trip/controller/TripInviteController.java
+++ b/src/main/java/com/tripmoa/trip/controller/TripInviteController.java
@@ -1,0 +1,34 @@
+package com.tripmoa.trip.controller;
+
+import com.tripmoa.security.principal.CustomUserDetails;
+import com.tripmoa.trip.dto.TripDetailResponse;
+import com.tripmoa.trip.dto.TripInviteResponse;
+import com.tripmoa.trip.service.TripInviteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/trips/invites")
+@RequiredArgsConstructor
+public class TripInviteController {
+
+    private final TripInviteService tripInviteService;
+
+    @GetMapping("/{inviteCode}")
+    public ResponseEntity<TripInviteResponse> getInviteInfo(
+            @PathVariable String inviteCode
+    ) {
+        return ResponseEntity.ok(tripInviteService.getInviteInfo(inviteCode));
+    }
+
+    @PostMapping("/{inviteCode}/join")
+    public ResponseEntity<TripDetailResponse> joinTrip(
+            @PathVariable String inviteCode,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(tripInviteService.joinTrip(inviteCode, userId));
+    }
+}

--- a/src/main/java/com/tripmoa/trip/dto/TripInviteResponse.java
+++ b/src/main/java/com/tripmoa/trip/dto/TripInviteResponse.java
@@ -1,0 +1,36 @@
+package com.tripmoa.trip.dto;
+
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.entity.TripMember;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class TripInviteResponse {
+
+    private Long tripId;
+    private String title;
+    private LocalDate tripStartDate;
+    private LocalDate tripEndDate;
+    private String ownerNickname;
+    private int memberCount;
+    private List<TripMemberResponse> members;
+
+    public static TripInviteResponse from(Trip trip, List<TripMember> members) {
+        return TripInviteResponse.builder()
+                .tripId(trip.getId())
+                .title(trip.getTitle())
+                .tripStartDate(trip.getTripStartDate())
+                .tripEndDate(trip.getTripEndDate())
+                .ownerNickname(trip.getOwner().getNickname())
+                .memberCount(members.size())
+                .members(members.stream()
+                        .map(TripMemberResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/tripmoa/trip/repository/TripRepository.java
+++ b/src/main/java/com/tripmoa/trip/repository/TripRepository.java
@@ -17,6 +17,9 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
     // 활성화된 여행 조회
     Optional<Trip> findByIdAndStatus(Long id, TripStatus status);
 
+    // 초대코드로 활성화된 여행 조회
+    Optional<Trip> findByInviteCodeAndStatus(String inviteCode, TripStatus status);
+
     // 내가 소유한 여행 전체 조회
     List<Trip> findAllByOwner_IdAndStatusOrderByCreatedAtDesc(Long userId, TripStatus status);
 

--- a/src/main/java/com/tripmoa/trip/service/TripInviteService.java
+++ b/src/main/java/com/tripmoa/trip/service/TripInviteService.java
@@ -1,0 +1,104 @@
+package com.tripmoa.trip.service;
+
+import com.tripmoa.global.exception.BusinessException;
+import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.trip.dto.TripDetailResponse;
+import com.tripmoa.trip.dto.TripInviteResponse;
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.entity.TripMember;
+import com.tripmoa.trip.enums.TripStatus;
+import com.tripmoa.trip.enums.TripVisibility;
+import com.tripmoa.trip.repository.TripMemberRepository;
+import com.tripmoa.trip.repository.TripRepository;
+import com.tripmoa.user.entity.User;
+import com.tripmoa.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TripInviteService {
+
+    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+    private final UserRepository userRepository;
+    private final TripMemberOrderService tripMemberOrderService;
+
+    @Transactional(readOnly = true)
+    public TripInviteResponse getInviteInfo(String inviteCode) {
+        Trip trip = getActiveTripByInviteCode(inviteCode);
+
+        List<TripMember> members =
+                tripMemberRepository.findAllByTrip_IdOrderBySortOrderAsc(trip.getId());
+
+        return TripInviteResponse.from(trip, members);
+    }
+
+    public TripDetailResponse joinTrip(String inviteCode, Long userId) {
+        Trip trip = getActiveTripByInviteCode(inviteCode);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (tripMemberRepository.existsByTrip_IdAndUser_Id(trip.getId(), userId)) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "이미 참여 중인 여행입니다.");
+        }
+
+        int nextSortOrder = tripMemberRepository.countByTrip_Id(trip.getId()) + 1;
+
+        String nickname = createUniqueNickname(trip.getId(), resolveNickname(user));
+
+        TripMember tripMember = TripMember.builder()
+                .trip(trip)
+                .user(user)
+                .nickname(nickname)
+                .sortOrder(nextSortOrder)
+                .build();
+
+        tripMemberRepository.save(tripMember);
+
+        if (trip.getVisibility() == TripVisibility.PRIVATE) {
+            trip.updateVisibility(TripVisibility.PUBLIC);
+        }
+
+        tripMemberOrderService.reorder(trip.getId());
+
+        List<TripMember> members =
+                tripMemberRepository.findAllByTrip_IdOrderBySortOrderAsc(trip.getId());
+
+        return TripDetailResponse.from(trip, members);
+    }
+
+    private Trip getActiveTripByInviteCode(String inviteCode) {
+        if (inviteCode == null || inviteCode.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST, "초대코드가 비어 있습니다.");
+        }
+
+        return tripRepository.findByInviteCodeAndStatus(inviteCode.trim().toUpperCase(), TripStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRIP_NOT_FOUND, "유효하지 않은 초대코드입니다."));
+    }
+
+    private String resolveNickname(User user) {
+        if (user.getNickname() != null && !user.getNickname().isBlank()) {
+            return user.getNickname();
+        }
+        return "사용자";
+    }
+
+    private String createUniqueNickname(Long tripId, String baseNickname) {
+        if (!tripMemberRepository.existsByTrip_IdAndNickname(tripId, baseNickname)) {
+            return baseNickname;
+        }
+
+        int index = 1;
+        while (tripMemberRepository.existsByTrip_IdAndNickname(tripId, baseNickname + "_" + index)) {
+            index++;
+        }
+
+        return baseNickname + "_" + index;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #112

---

## 🛠️ 작업 내용 (What)

- 초대코드를 기반으로 여행 정보를 조회하는 API를 추가했습니다.
- 사용자가 초대코드를 통해 여행에 참여할 수 있는 기능을 구현했습니다.
- 여행 참여 시 중복 참여 여부를 검증하도록 처리했습니다.
- 유효하지 않거나 비활성화된 초대코드에 대한 예외 처리를 추가했습니다.
- 초대코드 기반 여행 조회/참여 응답 DTO를 추가했습니다.

---

## 🧭 작업 목적 (Why)

기존에는 사용자가 직접 여행에 참여하기 위한 초대 흐름이 부족했습니다.

이를 개선하기 위해 초대코드 기반 여행 조회 및 참여 기능을 추가하여 사용자가 간편하게 여행에 참여할 수 있도록 했으며, 
서버에서 초대코드 유효성 및 중복 참여 여부를 일관되게 관리할 수 있도록 구현했습니다.

---

## 🧩 변경 범위

- [x] Controller
- [x] Service
- [ ] Domain(Entity)
- [x] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법

- [x] 로컬 서버 실행
- [x] 초대코드 조회 API 테스트
- [x] 초대코드 참여 API 테스트
- [x] 중복 참여 예외 확인
- [x] 유효하지 않은 초대코드 예외 확인
- [x] API 응답 확인

---

## ⚠️ 참고 사항

- 활성화된 여행만 초대코드 조회 및 참여가 가능합니다.
- 이미 참여 중인 사용자는 중복 참여할 수 없습니다.
- 초대코드 기반 조회 시 여행 기본 정보를 반환합니다.

---

## ✅ 체크리스트

- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료