### PR TITLE
[BE] feature: 여행 나가기 및 멤버 내보내기 기능 구현

### DIFF
--- a/src/main/java/com/tripmoa/expense/repository/DepositLogRepository.java
+++ b/src/main/java/com/tripmoa/expense/repository/DepositLogRepository.java
@@ -25,4 +25,7 @@ public interface DepositLogRepository extends JpaRepository<DepositLog, Long> {
     // 특정 여행의 특정 상태 입금 로그 조회
     List<DepositLog> findAllByTrip_IdAndDepositStatus(Long tripId, DepositLogStatus depositStatus);
 
+    // 특정 여행(tripId)에 입금 데이터가 하나라도 존재하는지 확인
+    boolean existsByTrip_Id(Long tripId);
+
 }

--- a/src/main/java/com/tripmoa/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/tripmoa/expense/repository/ExpenseRepository.java
@@ -50,4 +50,7 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
             """)
     Optional<Expense> findDetailByTripIdAndExpenseId(Long tripId, Long expenseId);
 
+    // 특정 여행(tripId)에 지출 데이터가 하나라도 존재하는지 확인
+    boolean existsByTrip_Id(Long tripId);
+
 }

--- a/src/main/java/com/tripmoa/trip/controller/TripController.java
+++ b/src/main/java/com/tripmoa/trip/controller/TripController.java
@@ -125,4 +125,28 @@ public class TripController {
         tripCommandService.deleteTrip(tripId, userId);
         return ResponseEntity.noContent().build();
     }
+
+    // 여행 나가기
+    @DeleteMapping("/{tripId}/members/me")
+    public ResponseEntity<Void> leaveTrip(
+            @PathVariable Long tripId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        tripCommandService.leaveTrip(tripId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 멤버 내보내기 / 탈퇴 유저 기록정리
+    @DeleteMapping("/{tripId}/members/{memberId}")
+    public ResponseEntity<Void> removeTripMember(
+            @PathVariable Long tripId,
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        tripCommandService.removeTripMember(tripId, memberId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/tripmoa/trip/entity/TripMember.java
+++ b/src/main/java/com/tripmoa/trip/entity/TripMember.java
@@ -58,4 +58,9 @@ public class TripMember {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updateSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
 }

--- a/src/main/java/com/tripmoa/trip/repository/TripMemberRepository.java
+++ b/src/main/java/com/tripmoa/trip/repository/TripMemberRepository.java
@@ -31,6 +31,21 @@ public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
     // 여행 목록 조회 시 여행마다 멤버를 개별 조회하지 않고 한 번에 가져와 N+1 문제를 방지하기 위한 메서드
     List<TripMember> findAllByTrip_IdInOrderByTrip_IdAscSortOrderAsc(List<Long> tripIds);
 
+    // 특정 여행의 멤버 수 조회
+    int countByTrip_Id(Long tripId);
+
+    // 특정 여행에 아직 멤버가 남아있는지 확인
+    boolean existsByTrip_Id(Long tripId);
+
+    // 특정 여행에서 특정 유저의 TripMember 조회
+    Optional<TripMember> findByTrip_IdAndUser_Id(Long tripId, Long userId);
+
+    // 나가는/삭제되는 멤버를 제외하고 다음 소유주 후보 조회
+    Optional<TripMember> findFirstByTrip_IdAndIdNotAndUserIsNotNullOrderBySortOrderAsc(
+            Long tripId,
+            Long memberId
+    );
+
     // 회원 탈퇴 시, 해당 유저가 참여 중이던 모든 여행 멤버 닉네임을 익명 처리
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/tripmoa/trip/service/TripCommandService.java
+++ b/src/main/java/com/tripmoa/trip/service/TripCommandService.java
@@ -4,6 +4,8 @@ import com.tripmoa.expense.entity.SettlementSetting;
 import com.tripmoa.expense.enums.PaymentMode;
 import com.tripmoa.expense.enums.PoolBalancePolicy;
 import com.tripmoa.expense.enums.SplitRemainderPolicy;
+import com.tripmoa.expense.repository.DepositLogRepository;
+import com.tripmoa.expense.repository.ExpenseRepository;
 import com.tripmoa.expense.repository.SettlementSettingRepository;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
@@ -43,6 +45,9 @@ public class TripCommandService {
     private final NoticeGroupRepository noticeGroupRepository;
     private final NoticeItemRepository noticeItemRepository;
     private final NoticeTagRepository noticeTagRepository;
+    private final TripMemberOrderService tripMemberOrderService;
+    private final ExpenseRepository expenseRepository;
+    private final DepositLogRepository depositLogRepository;
 
     // 여행 생성
     public TripDetailResponse createTrip(Long userId, TripCreateRequest request) {
@@ -304,12 +309,144 @@ public class TripCommandService {
         return TripMemberResponse.from(member);
     }
 
-    // 여행 삭제 -> 실제 삭제 X, ARCHIVED 처리
+    // 여행 삭제
     public void deleteTrip(Long tripId, Long userId) {
         tripPermissionService.assertOwner(tripId, userId);
+        assertNoSettlementData(tripId);
 
         Trip trip = tripPermissionService.getTripOr404(tripId);
-        trip.archive();
+
+        // 삭제 전 전체 멤버 수 조회
+        int beforeMemberCount = tripMemberRepository.countByTrip_Id(tripId);
+
+        // 소유주 혼자 남은 여행은 TripMember 행 삭제 없이 ARCHIVED 처리
+        if (beforeMemberCount == 1) {
+            trip.archive();
+            return;
+        }
+
+        TripMember ownerMember = getMemberByTripAndUser(tripId, userId);
+
+        // 멤버가 남아 있으면 다음 멤버에게 소유권 자동 양도
+        transferOwnerIfPossible(trip, ownerMember.getId());
+
+        // 기존 소유주 TripMember 행 삭제
+        tripMemberRepository.delete(ownerMember);
+        tripMemberRepository.flush();
+
+        // 삭제 후 남은 멤버 수에 따라 PUBLIC/PRIVATE 전환 및 재정렬
+        applyVisibilityAndOrderAfterMemberRemoval(trip);
+    }
+
+    // 여행 나가기
+    public void leaveTrip(Long tripId, Long userId) {
+        tripPermissionService.assertOwnerOrMember(tripId, userId);
+        assertNoSettlementData(tripId);
+
+        Trip trip = tripPermissionService.getTripOr404(tripId);
+        TripMember member = getMemberByTripAndUser(tripId, userId);
+
+        boolean isOwner = trip.getOwner().getId().equals(userId);
+
+        // 삭제 전 전체 멤버 수 조회
+        int beforeMemberCount = tripMemberRepository.countByTrip_Id(tripId);
+
+        // 소유주 혼자 남은 여행은 TripMember 행 삭제 없이 ARCHIVED 처리
+        if (isOwner && beforeMemberCount == 1) {
+            trip.archive();
+            return;
+        }
+
+        // 소유주가 나가는 경우 다음 멤버에게 소유권 자동 양도
+        if (isOwner) {
+            transferOwnerIfPossible(trip, member.getId());
+        }
+
+        // 나가는 사용자의 행 삭제
+        tripMemberRepository.delete(member);
+        tripMemberRepository.flush();
+
+        // 삭제 후 남은 멤버 수에 따라 PUBLIC/PRIVATE 전환 및 재정렬
+        applyVisibilityAndOrderAfterMemberRemoval(trip);
+    }
+
+    // 멤버 내보내기
+    public void removeTripMember(Long tripId, Long memberId, Long ownerId) {
+        tripPermissionService.assertOwner(tripId, ownerId);
+        assertNoSettlementData(tripId);
+
+        Trip trip = tripPermissionService.getTripOr404(tripId);
+
+        TripMember target = tripMemberRepository.findByIdAndTrip_Id(memberId, tripId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRIP_MEMBER_NOT_FOUND));
+
+        if (target.getUser() != null && target.getUser().getId().equals(ownerId)) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_REQUEST,
+                    "소유주는 내보낼 수 없습니다. 여행 나가기를 사용해주세요."
+            );
+        }
+
+        // 내보내는 사용자의 행 삭제
+        tripMemberRepository.delete(target);
+        tripMemberRepository.flush();
+
+        applyVisibilityAndOrderAfterMemberRemoval(trip);
+    }
+
+    // 특정 여행에서 특정 사용자의 TripMember 조회
+    private TripMember getMemberByTripAndUser(Long tripId, Long userId) {
+        return tripMemberRepository.findByTrip_IdAndUser_Id(tripId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRIP_MEMBER_NOT_FOUND));
+    }
+
+    // 여행 지출 또는 입금 내역 존재 여부 확인
+    private void assertNoSettlementData(Long tripId) {
+        boolean hasExpense = expenseRepository.existsByTrip_Id(tripId);
+        boolean hasDeposit = depositLogRepository.existsByTrip_Id(tripId);
+
+        if (hasExpense || hasDeposit) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_REQUEST,
+                    "지출 또는 입금 내역이 있는 여행에서는 실행 할 수 없습니다."
+            );
+        }
+    }
+
+    // 현재 소유주가 빠질 때 다음 멤버에게 소유권을 자동 양도
+    private void transferOwnerIfPossible(Trip trip, Long leavingMemberId) {
+        TripMember nextOwner = tripMemberRepository
+                .findFirstByTrip_IdAndIdNotAndUserIsNotNullOrderBySortOrderAsc(
+                        trip.getId(),
+                        leavingMemberId
+                )
+                .orElse(null);
+
+        if (nextOwner == null) {
+            return;
+        }
+
+        trip.changeOwner(nextOwner.getUser());
+    }
+
+    // 멤버 삭제 후 남은 멤버 수에 따라 공개 여부와 정렬 순서를 정리
+    private void applyVisibilityAndOrderAfterMemberRemoval(Trip trip) {
+        Long tripId = trip.getId();
+
+        int memberCount = tripMemberRepository.countByTrip_Id(tripId);
+
+        if (memberCount == 0) {
+            trip.archive();
+            return;
+        }
+
+        if (memberCount == 1) {
+            trip.updateVisibility(TripVisibility.PRIVATE);
+        } else {
+            trip.updateVisibility(TripVisibility.PUBLIC);
+        }
+
+        tripMemberOrderService.reorder(tripId);
     }
 
     private void validateTripDates(java.time.LocalDate startDate, java.time.LocalDate endDate) {
@@ -324,5 +461,6 @@ public class TripCommandService {
         }
         return "사용자";
     }
+
 }
 

--- a/src/main/java/com/tripmoa/trip/service/TripMemberOrderService.java
+++ b/src/main/java/com/tripmoa/trip/service/TripMemberOrderService.java
@@ -1,0 +1,55 @@
+package com.tripmoa.trip.service;
+
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.entity.TripMember;
+import com.tripmoa.trip.repository.TripMemberRepository;
+import com.tripmoa.trip.repository.TripRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TripMemberOrderService {
+
+    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+
+    public void reorder(Long tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow();
+
+        Long ownerId = trip.getOwner().getId();
+
+        List<TripMember> members =
+                tripMemberRepository.findAllByTrip_IdOrderBySortOrderAsc(tripId);
+
+        List<TripMember> sortedMembers = members.stream()
+                .sorted(
+                        Comparator
+                                .comparing((TripMember member) -> !isOwner(member, ownerId))
+                                .thenComparing(this::isInactive)
+                                .thenComparing(TripMember::getSortOrder)
+                                .thenComparing(TripMember::getId)
+                )
+                .toList();
+
+        for (int i = 0; i < sortedMembers.size(); i++) {
+            sortedMembers.get(i).updateSortOrder(i + 1);
+        }
+    }
+
+    private boolean isOwner(TripMember member, Long ownerId) {
+        return member.getUser() != null
+                && member.getUser().getId().equals(ownerId);
+    }
+
+    private boolean isInactive(TripMember member) {
+        return member.getUser() == null
+                || "알수 없음".equals(member.getNickname());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #113

---

## 🛠️ 작업 내용 (What)

- 여행 멤버가 직접 여행에서 나갈 수 있는 API를 추가했습니다.
- 여행 소유자가 특정 멤버를 여행에서 내보낼 수 있는 API를 추가했습니다.
- 여행 소유자가 나가거나 제거되는 경우 다음 멤버에게 소유권이 이전되도록 로직을 구현했습니다.
- 멤버 변경 이후 여행 멤버 순서를 재정렬하는 로직을 추가했습니다.
- 입금 및 지출 데이터 존재 여부를 기반으로 여행 삭제 가능 여부를 검증하도록 개선했습니다.

---

## 🧭 작업 목적 (Why)

기존에는 여행 멤버 관리 및 소유권 이전 흐름이 부족하여 멤버 탈퇴/제거 상황에서 데이터 정합성과 권한 관리 문제가 발생할 수 있었습니다.

이를 개선하기 위해 여행 나가기 및 멤버 내보내기 기능을 추가하고, 소유권 이전 및 멤버 순서 재정렬 로직을 함께 구현하여 여행 상태를 일관되게 유지할 수 있도록 개선했습니다.

또한 정산 관련 데이터가 존재하는 경우 여행 삭제를 제한하여 데이터 무결성을 강화했습니다.

---

## 🧩 변경 범위

- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법

- [x] 로컬 서버 실행
- [x] 여행 나가기 API 테스트
- [x] 멤버 내보내기 API 테스트
- [x] 소유권 이전 동작 확인
- [x] 멤버 순서 재정렬 확인
- [x] 삭제 제한 검증 확인
- [x] 예외 케이스 확인

---

## ⚠️ 참고 사항

- 여행 소유자가 나가는 경우 다음 멤버에게 자동으로 소유권이 이전됩니다.
- 멤버 삭제 후 TripMember sortOrder가 재정렬됩니다.
- 입금/지출 데이터가 존재하는 경우 여행 삭제가 제한됩니다.
- 마지막 남은 멤버가 나가는 경우 여행 상태 처리 로직이 함께 수행됩니다.

---

## ✅ 체크리스트

- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료