### PR TITLE
[BE] auth: Story API 인증 정책 추가

### DIFF
--- a/src/main/java/com/tripmoa/global/config/SecurityConfig.java
+++ b/src/main/java/com/tripmoa/global/config/SecurityConfig.java
@@ -81,7 +81,10 @@ public class SecurityConfig {
                         // OCR 프록시: 로그인 필요 (의도적으로 명시)
                         .requestMatchers(HttpMethod.POST, "/api/trips/*/expenses/ocr/**").authenticated()
 
-                        // Mate : 로그인 필요한 엔드포인트
+                        // Story, Mate : 로그인 필요한 엔드포인트
+                        .requestMatchers(HttpMethod.GET, "/api/stories/my").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/stories/liked").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/stories/followed").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/mate/posts/passed").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/mate/applications/**").authenticated()
 
@@ -94,7 +97,11 @@ public class SecurityConfig {
                         .requestMatchers("/api/schedule-items/**").permitAll()
 
                         // 비로그인 사용자도 볼 수 있는 데이터 (Public API) GET 경로만 허용
-                        // .requestMatchers(HttpMethod.GET, "/api/stories/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/users/styles").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/stories").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/stories/{id}").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/stories/{id}/view").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/stories/{id}/comments").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/mate/**").permitAll()
 
                         // Swagger 경로 허용


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #115

---

## 🛠️ 작업 내용 (What)

- SecurityConfig에 Story API 접근 정책을 추가했습니다.
- Story 관련 API의 인증 필요 여부를 구분하여 접근 제어 규칙을 설정했습니다.
- 공개 API와 인증 필요 API를 분리하여 보안 정책을 정리했습니다.

---

## 🧭 작업 목적 (Why)

기존 SecurityConfig에는 Story API 관련 접근 정책이 명확하게 정리되어 있지 않아 새로운 Story 기능 추가 시 인증 정책 관리가 어려웠습니다.

이를 개선하기 위해 Story API 인증 정책을 추가하고, 공개 API와 인증 API를 구분하여 접근 제어 흐름을 명확하게 관리할 수 있도록 보안 설정을 보완했습니다.

---

## 🧩 변경 범위

- [x] Security Config
- [ ] Filter / Interceptor
- [x] API 접근 정책
- [ ] DB 스키마

---

## 🧪 테스트 방법

- [x] 로컬 서버 실행
- [x] 비회원 접근 허용 API 테스트
- [x] 인증 필요 API 접근 테스트
- [x] 인증 실패 시 401 응답 확인
- [x] 기존 API 영향 여부 확인

---

## ⚠️ 참고 사항

- Story API 엔드포인트별 인증 정책이 추가되었습니다.
- 공개 API와 인증 필요 API가 분리되어 관리됩니다.
- 기존 API 동작에는 영향 없이 접근 정책만 추가되었습니다.

---

## ✅ 체크리스트

- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료