### PR TITLE
[BE] feature: Mate 게시글 AI 자동 태그 추출 및 저장 시스템 구현

### DIFF
--- a/src/main/java/com/tripmoa/TripMoaApplication.java
+++ b/src/main/java/com/tripmoa/TripMoaApplication.java
@@ -2,8 +2,10 @@ package com.tripmoa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class TripMoaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/tripmoa/mate/domain/MatePost.java
+++ b/src/main/java/com/tripmoa/mate/domain/MatePost.java
@@ -8,6 +8,7 @@ import com.tripmoa.matetag.domain.MatePostTag;
 import com.tripmoa.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -68,6 +69,7 @@ public class MatePost {
     private AgeGroup ageGroup;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "post")
+    @BatchSize(size = 20)
     @Builder.Default
     private List<MatePostTag> tags = new ArrayList<>();
 

--- a/src/main/java/com/tripmoa/mate/domain/MatePost.java
+++ b/src/main/java/com/tripmoa/mate/domain/MatePost.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tripmoa.mate.enums.AgeGroup;
 import com.tripmoa.mate.enums.GenderPreference;
 import com.tripmoa.mate.enums.Transport;
+import com.tripmoa.matetag.domain.MatePostTag;
 import com.tripmoa.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,6 +12,8 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -64,8 +67,9 @@ public class MatePost {
     @Enumerated(EnumType.STRING)
     private AgeGroup ageGroup;
 
-//    @Enumerated(EnumType.STRING)
-//    private Set<Tag> tags;
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "post")
+    @Builder.Default
+    private List<MatePostTag> tags = new ArrayList<>();
 
     // 조회수, 좋아요
     @Column

--- a/src/main/java/com/tripmoa/mate/dto/MateResponse.java
+++ b/src/main/java/com/tripmoa/mate/dto/MateResponse.java
@@ -4,10 +4,12 @@ import com.tripmoa.mate.enums.AgeGroup;
 import com.tripmoa.mate.enums.GenderPreference;
 import com.tripmoa.mate.domain.MatePost;
 import com.tripmoa.mate.enums.Transport;
+import com.tripmoa.matetag.dto.MateTagResponse;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 @Getter
@@ -26,7 +28,7 @@ public class MateResponse {
     private Transport transport;
     private GenderPreference genderPreference;
     private AgeGroup ageGroup;
-//    private Set<Tag> tags;
+    private List<MateTagResponse> tags;
     private Long likesCount;
     private Long viewsCount;
     private LocalDateTime createdAt;
@@ -48,6 +50,9 @@ public class MateResponse {
                 .transport(matePost.getTransport())
                 .genderPreference(matePost.getGenderPreference())
                 .ageGroup(matePost.getAgeGroup())
+                .tags(matePost.getTags().stream()
+                    .map(pt -> new MateTagResponse(pt.getTag().getName(), pt.getTag().getCategory()))
+                    .toList())
                 .likesCount(matePost.getLikesCount())
                 .viewsCount(matePost.getViewsCount())
                 .createdAt(matePost.getCreatedAt())

--- a/src/main/java/com/tripmoa/mate/service/MateService.java
+++ b/src/main/java/com/tripmoa/mate/service/MateService.java
@@ -5,19 +5,17 @@ import com.tripmoa.mate.domain.MatePost;
 import com.tripmoa.mate.domain.MateDomain;
 import com.tripmoa.mate.dto.MateRequest;
 import com.tripmoa.mate.dto.MateResponse;
-import com.tripmoa.mate.repository.ApplicationRepository;
 import com.tripmoa.mate.repository.MateRepository;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
+import com.tripmoa.matetag.event.MatePostCreatedEvent;
 import com.tripmoa.user.entity.User;
-import com.tripmoa.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -34,6 +32,7 @@ public class MateService {
     private final ViewCountService viewCountService;
     private final MateDomain domain;
     private final BadWordFilter badWordFilter;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public List<MateResponse> getMatePosts(Long userId) {
         List<MatePost> matePosts = mateRepository.findAllWithUser();
@@ -75,6 +74,15 @@ public class MateService {
 
         domain.validateCreate(post);
         mateRepository.save(post);
+        applicationEventPublisher.publishEvent(
+                new MatePostCreatedEvent(
+                        post.getId(),
+                        post.getContent(),
+                        post.getDestination(),
+                        post.getBudget(),
+                        post.getMaxParticipant(),
+                        post.getStartDate(),
+                        post.getEndDate()));
         return MateResponse.from(post);
     }
 

--- a/src/main/java/com/tripmoa/mate/service/MateService.java
+++ b/src/main/java/com/tripmoa/mate/service/MateService.java
@@ -78,11 +78,7 @@ public class MateService {
                 new MatePostCreatedEvent(
                         post.getId(),
                         post.getContent(),
-                        post.getDestination(),
-                        post.getBudget(),
-                        post.getMaxParticipant(),
-                        post.getStartDate(),
-                        post.getEndDate()));
+                        post.getDestination()));
         return MateResponse.from(post);
     }
 

--- a/src/main/java/com/tripmoa/matetag/client/FastApiTagClient.java
+++ b/src/main/java/com/tripmoa/matetag/client/FastApiTagClient.java
@@ -2,28 +2,55 @@ package com.tripmoa.matetag.client;
 
 import com.tripmoa.matetag.dto.FastApiTagRequest;
 import com.tripmoa.matetag.dto.FastApiTagResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
 
 @Component
+@Slf4j
 public class FastApiTagClient {
 
-    private final RestClient restClient;
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
 
     public FastApiTagClient(@Value("${ai.server.url}") String baseUrl) {
-        this.restClient = RestClient.builder()
-                .baseUrl(baseUrl)
-                .build();
+        this.restTemplate = new RestTemplate();
+        this.baseUrl = baseUrl;
     }
 
     public FastApiTagResponse extractTags(FastApiTagRequest request) {
-        return restClient.post()
-                .uri("/mate/extract")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(request)
-                .retrieve()
-                .body(FastApiTagResponse.class);
+        log.info("FastAPI 요청: {}", request);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<FastApiTagRequest> entity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<FastApiTagResponse> response = restTemplate.postForEntity(
+                baseUrl + "/mate/extract", entity, FastApiTagResponse.class);
+
+        return response.getBody();
     }
+
+//    private final RestClient restClient;
+//
+//    public FastApiTagClient(@Value("${ai.server.url}") String baseUrl) {
+//        this.restClient = RestClient.builder()
+//                .baseUrl(baseUrl)
+//                .build();
+//    }
+//
+//    public FastApiTagResponse extractTags(FastApiTagRequest request) {
+//        return restClient.post()
+//                .uri("/mate/extract")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .body(request)
+//                .retrieve()
+//                .body(FastApiTagResponse.class);
+//    }
 }

--- a/src/main/java/com/tripmoa/matetag/client/FastApiTagClient.java
+++ b/src/main/java/com/tripmoa/matetag/client/FastApiTagClient.java
@@ -1,0 +1,29 @@
+package com.tripmoa.matetag.client;
+
+import com.tripmoa.matetag.dto.FastApiTagRequest;
+import com.tripmoa.matetag.dto.FastApiTagResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class FastApiTagClient {
+
+    private final RestClient restClient;
+
+    public FastApiTagClient(@Value("${ai.server.url}") String baseUrl) {
+        this.restClient = RestClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+    }
+
+    public FastApiTagResponse extractTags(FastApiTagRequest request) {
+        return restClient.post()
+                .uri("/mate/extract")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(FastApiTagResponse.class);
+    }
+}

--- a/src/main/java/com/tripmoa/matetag/client/FastApiTagClient.java
+++ b/src/main/java/com/tripmoa/matetag/client/FastApiTagClient.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
 @Component
@@ -25,8 +24,6 @@ public class FastApiTagClient {
     }
 
     public FastApiTagResponse extractTags(FastApiTagRequest request) {
-        log.info("FastAPI 요청: {}", request);
-
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<FastApiTagRequest> entity = new HttpEntity<>(request, headers);
@@ -36,21 +33,4 @@ public class FastApiTagClient {
 
         return response.getBody();
     }
-
-//    private final RestClient restClient;
-//
-//    public FastApiTagClient(@Value("${ai.server.url}") String baseUrl) {
-//        this.restClient = RestClient.builder()
-//                .baseUrl(baseUrl)
-//                .build();
-//    }
-//
-//    public FastApiTagResponse extractTags(FastApiTagRequest request) {
-//        return restClient.post()
-//                .uri("/mate/extract")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .body(request)
-//                .retrieve()
-//                .body(FastApiTagResponse.class);
-//    }
 }

--- a/src/main/java/com/tripmoa/matetag/controller/MateTagController.java
+++ b/src/main/java/com/tripmoa/matetag/controller/MateTagController.java
@@ -1,6 +1,8 @@
 package com.tripmoa.matetag.controller;
 
 import com.tripmoa.matetag.dto.MateTagResponse;
+import com.tripmoa.matetag.service.MateTagService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,11 +12,14 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/mate")
+@RequiredArgsConstructor
 public class MateTagController {
+
+    private final MateTagService tagService;
 
     @GetMapping("/tags")
     public ResponseEntity<List<MateTagResponse>> readTagList() {
-        List<MateTagResponse> tags = null;
+        List<MateTagResponse> tags = this.tagService.getAllTags();
         return ResponseEntity.ok().body(tags);
     }
 }

--- a/src/main/java/com/tripmoa/matetag/controller/MateTagController.java
+++ b/src/main/java/com/tripmoa/matetag/controller/MateTagController.java
@@ -1,0 +1,20 @@
+package com.tripmoa.matetag.controller;
+
+import com.tripmoa.matetag.dto.MateTagResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/mate")
+public class MateTagController {
+
+    @GetMapping("/tags")
+    public ResponseEntity<List<MateTagResponse>> readTagList() {
+        List<MateTagResponse> tags = null;
+        return ResponseEntity.ok().body(tags);
+    }
+}

--- a/src/main/java/com/tripmoa/matetag/domain/MatePostTag.java
+++ b/src/main/java/com/tripmoa/matetag/domain/MatePostTag.java
@@ -6,11 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name="mate_post_tag")
 @Getter
 @Builder
 @NoArgsConstructor
@@ -28,7 +28,6 @@ public class MatePostTag {
     @ManyToOne(fetch=FetchType.LAZY)
     @MapsId("tagId")
     @JoinColumn(name="mate_tag_id", nullable=false)
-    @BatchSize(size = 20)
     private MateTag tag;
 
     private Boolean isAiGenerated = true;

--- a/src/main/java/com/tripmoa/matetag/domain/MatePostTag.java
+++ b/src/main/java/com/tripmoa/matetag/domain/MatePostTag.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDateTime;
 
@@ -27,6 +28,7 @@ public class MatePostTag {
     @ManyToOne(fetch=FetchType.LAZY)
     @MapsId("tagId")
     @JoinColumn(name="mate_tag_id", nullable=false)
+    @BatchSize(size = 20)
     private MateTag tag;
 
     private Boolean isAiGenerated = true;

--- a/src/main/java/com/tripmoa/matetag/domain/MatePostTag.java
+++ b/src/main/java/com/tripmoa/matetag/domain/MatePostTag.java
@@ -1,0 +1,35 @@
+package com.tripmoa.matetag.domain;
+
+import com.tripmoa.mate.domain.MatePost;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatePostTag {
+
+    @EmbeddedId
+    private MatePostTagId id;
+
+    @ManyToOne(fetch= FetchType.LAZY)
+    @MapsId("postId")
+    @JoinColumn(name="mate_post_id", nullable=false)
+    private MatePost post;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @MapsId("tagId")
+    @JoinColumn(name="mate_tag_id", nullable=false)
+    private MateTag tag;
+
+    private Boolean isAiGenerated = true;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/tripmoa/matetag/domain/MatePostTagId.java
+++ b/src/main/java/com/tripmoa/matetag/domain/MatePostTagId.java
@@ -1,0 +1,17 @@
+package com.tripmoa.matetag.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatePostTagId implements Serializable {
+    private Long postId;
+    private Long tagId;
+}

--- a/src/main/java/com/tripmoa/matetag/domain/MateTag.java
+++ b/src/main/java/com/tripmoa/matetag/domain/MateTag.java
@@ -1,0 +1,24 @@
+package com.tripmoa.matetag.domain;
+
+import com.tripmoa.matetag.enums.MateTagCategory;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MateTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private MateTagCategory category;
+
+}

--- a/src/main/java/com/tripmoa/matetag/domain/MateTag.java
+++ b/src/main/java/com/tripmoa/matetag/domain/MateTag.java
@@ -4,10 +4,13 @@ import com.tripmoa.matetag.enums.MateTagCategory;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
+@Table(name="mate_tags")
 @Getter
 @NoArgsConstructor
+@BatchSize(size=20)
 public class MateTag {
 
     @Id

--- a/src/main/java/com/tripmoa/matetag/dto/FastApiTagRequest.java
+++ b/src/main/java/com/tripmoa/matetag/dto/FastApiTagRequest.java
@@ -1,0 +1,15 @@
+package com.tripmoa.matetag.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+public record FastApiTagRequest(
+        @JsonProperty("post_id") Long postId,
+        String content,
+        String destination,
+        Integer budget,
+        @JsonProperty("member_count") Integer memberCount,
+        @JsonProperty("start_date") LocalDate startDate,
+        @JsonProperty("end_date") LocalDate endDate
+    ) {}

--- a/src/main/java/com/tripmoa/matetag/dto/FastApiTagRequest.java
+++ b/src/main/java/com/tripmoa/matetag/dto/FastApiTagRequest.java
@@ -7,9 +7,5 @@ import java.time.LocalDate;
 public record FastApiTagRequest(
         @JsonProperty("post_id") Long postId,
         String content,
-        String destination,
-        Integer budget,
-        @JsonProperty("member_count") Integer memberCount,
-        @JsonProperty("start_date") LocalDate startDate,
-        @JsonProperty("end_date") LocalDate endDate
+        String destination
     ) {}

--- a/src/main/java/com/tripmoa/matetag/dto/FastApiTagResponse.java
+++ b/src/main/java/com/tripmoa/matetag/dto/FastApiTagResponse.java
@@ -1,0 +1,12 @@
+package com.tripmoa.matetag.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record FastApiTagResponse(
+        @JsonProperty("post_id") Long postId,
+        @JsonProperty("style_tags") List<String> styleTags,
+        @JsonProperty("vibe_tags") List<String> vibeTags
+) {
+}

--- a/src/main/java/com/tripmoa/matetag/dto/MateTagResponse.java
+++ b/src/main/java/com/tripmoa/matetag/dto/MateTagResponse.java
@@ -1,0 +1,5 @@
+package com.tripmoa.matetag.dto;
+
+import com.tripmoa.matetag.enums.MateTagCategory;
+
+public record MateTagResponse(String name, MateTagCategory category) {}

--- a/src/main/java/com/tripmoa/matetag/enums/MateTagCategory.java
+++ b/src/main/java/com/tripmoa/matetag/enums/MateTagCategory.java
@@ -1,0 +1,10 @@
+package com.tripmoa.matetag.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public enum MateTagCategory {
+    STYLE,
+    VIBE
+}

--- a/src/main/java/com/tripmoa/matetag/event/MatePostCreatedEvent.java
+++ b/src/main/java/com/tripmoa/matetag/event/MatePostCreatedEvent.java
@@ -1,0 +1,14 @@
+package com.tripmoa.matetag.event;
+
+import java.time.LocalDate;
+
+public record MatePostCreatedEvent
+        (Long postId,
+         String content,
+         String destination,
+         Integer budget,
+         Integer memberCount,
+         LocalDate startDate,
+         LocalDate endDate
+        ) {
+}

--- a/src/main/java/com/tripmoa/matetag/event/MatePostCreatedEvent.java
+++ b/src/main/java/com/tripmoa/matetag/event/MatePostCreatedEvent.java
@@ -5,10 +5,6 @@ import java.time.LocalDate;
 public record MatePostCreatedEvent
         (Long postId,
          String content,
-         String destination,
-         Integer budget,
-         Integer memberCount,
-         LocalDate startDate,
-         LocalDate endDate
+         String destination
         ) {
 }

--- a/src/main/java/com/tripmoa/matetag/event/MateTagEventListener.java
+++ b/src/main/java/com/tripmoa/matetag/event/MateTagEventListener.java
@@ -1,5 +1,7 @@
 package com.tripmoa.matetag.event;
 
+import com.tripmoa.mate.domain.MatePost;
+import com.tripmoa.mate.repository.MateRepository;
 import com.tripmoa.matetag.client.FastApiTagClient;
 import com.tripmoa.matetag.domain.MatePostTag;
 import com.tripmoa.matetag.domain.MatePostTagId;
@@ -27,6 +29,7 @@ public class MateTagEventListener {
     private final FastApiTagClient fastApiTagClient;
     private final MateTagRepository tagRepository;
     private final MatePostTagRepository postTagRepository;
+    private final MateRepository mateRepository;
 
     @Async
     @TransactionalEventListener(phase=AFTER_COMMIT)
@@ -36,11 +39,7 @@ public class MateTagEventListener {
                     new FastApiTagRequest(
                             event.postId(),
                             event.content(),
-                            event.destination(),
-                            event.budget(),
-                            event.memberCount(),
-                            event.startDate(),
-                            event.endDate()
+                            event.destination()
                     )
             );
 
@@ -49,10 +48,12 @@ public class MateTagEventListener {
             tagNames.addAll(response.vibeTags());
 
             List<MateTag> tags = tagRepository.findByNameIn(tagNames);
+            MatePost postRef = mateRepository.getReferenceById(event.postId());
 
             List<MatePostTag> postTags = tags.stream()
                     .map(tag -> MatePostTag.builder()
                             .id(new MatePostTagId(event.postId(), tag.getId()))
+                            .post(postRef)
                             .tag(tag)
                             .build())
                     .toList();

--- a/src/main/java/com/tripmoa/matetag/event/MateTagEventListener.java
+++ b/src/main/java/com/tripmoa/matetag/event/MateTagEventListener.java
@@ -1,0 +1,66 @@
+package com.tripmoa.matetag.event;
+
+import com.tripmoa.matetag.client.FastApiTagClient;
+import com.tripmoa.matetag.domain.MatePostTag;
+import com.tripmoa.matetag.domain.MatePostTagId;
+import com.tripmoa.matetag.domain.MateTag;
+import com.tripmoa.matetag.dto.FastApiTagRequest;
+import com.tripmoa.matetag.dto.FastApiTagResponse;
+import com.tripmoa.matetag.repository.MatePostTagRepository;
+import com.tripmoa.matetag.repository.MateTagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MateTagEventListener {
+
+    private final FastApiTagClient fastApiTagClient;
+    private final MateTagRepository tagRepository;
+    private final MatePostTagRepository postTagRepository;
+
+    @Async
+    @TransactionalEventListener(phase=AFTER_COMMIT)
+    public void handleTagExtraction(MatePostCreatedEvent event) {
+        try {
+            FastApiTagResponse response = fastApiTagClient.extractTags(
+                    new FastApiTagRequest(
+                            event.postId(),
+                            event.content(),
+                            event.destination(),
+                            event.budget(),
+                            event.memberCount(),
+                            event.startDate(),
+                            event.endDate()
+                    )
+            );
+
+            List<String> tagNames = new ArrayList<>();
+            tagNames.addAll(response.styleTags());
+            tagNames.addAll(response.vibeTags());
+
+            List<MateTag> tags = tagRepository.findByNameIn(tagNames);
+
+            List<MatePostTag> postTags = tags.stream()
+                    .map(tag -> MatePostTag.builder()
+                            .id(new MatePostTagId(event.postId(), tag.getId()))
+                            .tag(tag)
+                            .build())
+                    .toList();
+
+            postTagRepository.saveAll(postTags);
+        } catch (Exception e) {
+            log.error("태그 추출 실패 - postId: {}", event.postId(), e);
+        }
+    }
+
+}

--- a/src/main/java/com/tripmoa/matetag/repository/MatePostTagRepository.java
+++ b/src/main/java/com/tripmoa/matetag/repository/MatePostTagRepository.java
@@ -1,0 +1,8 @@
+package com.tripmoa.matetag.repository;
+
+import com.tripmoa.matetag.domain.MatePostTag;
+import com.tripmoa.matetag.domain.MatePostTagId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatePostTagRepository extends JpaRepository<MatePostTag, MatePostTagId> {
+}

--- a/src/main/java/com/tripmoa/matetag/repository/MateTagRepository.java
+++ b/src/main/java/com/tripmoa/matetag/repository/MateTagRepository.java
@@ -3,5 +3,8 @@ package com.tripmoa.matetag.repository;
 import com.tripmoa.matetag.domain.MateTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MateTagRepository extends JpaRepository<MateTag, Long> {
+    List<MateTag> findByNameIn(List<String> tagNames);
 }

--- a/src/main/java/com/tripmoa/matetag/repository/MateTagRepository.java
+++ b/src/main/java/com/tripmoa/matetag/repository/MateTagRepository.java
@@ -1,0 +1,7 @@
+package com.tripmoa.matetag.repository;
+
+import com.tripmoa.matetag.domain.MateTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MateTagRepository extends JpaRepository<MateTag, Long> {
+}

--- a/src/main/java/com/tripmoa/matetag/service/MateTagService.java
+++ b/src/main/java/com/tripmoa/matetag/service/MateTagService.java
@@ -1,0 +1,20 @@
+package com.tripmoa.matetag.service;
+
+import com.tripmoa.matetag.dto.MateTagResponse;
+import com.tripmoa.matetag.repository.MateTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MateTagService {
+    private final MateTagRepository tagRepository;
+
+    public List<MateTagResponse> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(tag -> new MateTagResponse(tag.getName(), tag.getCategory()))
+                .toList();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #123 

---
## 🛠️ 작업 내용 (What)
- `MateTag`, `MatePostTag` 엔티티 및 리포지토리 추가 (`@EmbeddedId` + `@MapsId` 복합키 패턴)
- 태그 목록 조회 API 구현 (`GET /api/mate/tags`)
- 글 작성 시 Spring Event 기반 비동기 FastAPI 호출 → AI 태그 추출 → `mate_post_tag` 저장
- 게시글 조회 응답 DTO에 `tags` 필드 추가, `@BatchSize`로 N+1 방지

---
## 🧭 작업 목적 (Why)
동행 매칭 추천 시스템의 입력 데이터로 활용할 AI 태그를 자동 부여한다. 글 저장 트랜잭션과 태그 추출을 `@TransactionalEventListener(AFTER_COMMIT)` + `@Async`로 완전 분리하여, 태그 추출 실패가 글 작성에 영향을 주지 않는 구조를 만든다.

---
## 🧩 변경 범위
- [x] Controller — `MateTagController` (태그 목록 API)
- [x] Service — `MateTagService`, `MateService`(이벤트 발행 추가)
- [x] Domain(Entity) — `MateTag`, `MatePostTag`, `MatePostTagId`, `MateTagCategory`, `MatePost`(수정)
- [x] Repository — `MateTagRepository`(`findByNameIn` 추가), `MatePostTagRepository`
- [x] API 설계 — `GET /api/mate/tags`, 기존 조회 API 응답 확장
- [x] DB 스키마 — `mate_tags`, `mate_post_tag` 테이블 신규 생성, 초기 데이터 17개 INSERT

---
## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 — `curl http://localhost:8080/api/mate/tags` → 17개 태그 반환 확인
- [x] 예외 케이스 확인 — FastAPI 미기동 시 글 작성 정상 동작, 로그에 `태그 추출 실패` 기록 확인
- [x] 글 작성 후 `SELECT * FROM mate_post_tag WHERE mate_post_id = {id}`로 태그 저장 확인

---
## ⚠️ 참고 사항
- `RestClient`에서 빈 바디 전송 문제로 `RestTemplate`을 사용함
- FastAPI 서버가 띄워진 상태에서 테스트해야 전체 플로우 확인 가능

---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료

---