### PR TITLE
[BE] fix: Place API 권한/에러 처리 보완 및 메모 기능 제거

### DIFF
--- a/src/main/java/com/tripmoa/ai/domain/AiClient.java
+++ b/src/main/java/com/tripmoa/ai/domain/AiClient.java
@@ -1,26 +1,40 @@
 package com.tripmoa.ai.domain;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tripmoa.ai.dto.AiScheduleRequest;
 import com.tripmoa.ai.dto.AiScheduleResponse;
 import com.tripmoa.expense.dto.request.OcrLlmRequest;
 import com.tripmoa.expense.dto.response.OcrLlmResponse;
 import com.tripmoa.place.dto.PlaceSearchResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.SocketTimeoutException;
 
 /**
  * AiClient
  * - Python AI 서버와 통신하는 전용 클래스
  * - 일정 생성 + 장소 검색 두 가지 역할
+ *
+ * Python(FastAPI)이 던지는 400 등의 구체적인 사유({"detail": "..."})를
+ * 그대로 살려서 프론트에 전달한다 — 안 그러면 전부 범용 500으로 뭉개짐.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AiClient {
 
     private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Value("${ai.server.url}")
     private String aiServerUrl;
@@ -28,7 +42,13 @@ public class AiClient {
     // AI 일정 생성
     public AiScheduleResponse generate(AiScheduleRequest request) {
         String url = aiServerUrl + "/schedule/generate";
-        return restTemplate.postForObject(url, request, AiScheduleResponse.class);
+        try {
+            return restTemplate.postForObject(url, request, AiScheduleResponse.class);
+        } catch (HttpStatusCodeException e) {
+            throw new ResponseStatusException(e.getStatusCode(), extractDetail(e), e);
+        } catch (ResourceAccessException e) {
+            throw toTimeoutOrUnavailable(e);
+        }
     }
 
     // 장소 검색 프록시
@@ -41,7 +61,13 @@ public class AiClient {
                 .build()
                 .encode()
                 .toUri();
-        return restTemplate.getForObject(uri, PlaceSearchResponse.class);
+        try {
+            return restTemplate.getForObject(uri, PlaceSearchResponse.class);
+        } catch (HttpStatusCodeException e) {
+            throw new ResponseStatusException(e.getStatusCode(), extractDetail(e), e);
+        } catch (ResourceAccessException e) {
+            throw toTimeoutOrUnavailable(e);
+        }
     }
 
     // OCR 영수증 LLM 분석
@@ -50,4 +76,30 @@ public class AiClient {
         return restTemplate.postForObject(url, request, OcrLlmResponse.class);
     }
 
+    // Python(FastAPI)의 HTTPException 응답은 {"detail": "..."} 형태 — 최대한 그 사유를 그대로 전달
+    private String extractDetail(HttpStatusCodeException e) {
+        try {
+            JsonNode node = objectMapper.readTree(e.getResponseBodyAsString());
+            JsonNode detail = node.get("detail");
+            if (detail != null && detail.isTextual()) return detail.asText();
+        } catch (Exception parseError) {
+            log.warn("AI 서버 에러 응답 파싱 실패: {}", e.getResponseBodyAsString());
+        }
+        return "AI 서버 요청이 실패했습니다.";
+    }
+
+    private ResponseStatusException toTimeoutOrUnavailable(ResourceAccessException e) {
+        if (e.getCause() instanceof SocketTimeoutException) {
+            return new ResponseStatusException(
+                    HttpStatus.GATEWAY_TIMEOUT,
+                    "AI 서버 응답이 너무 오래 걸립니다. 잠시 후 다시 시도해주세요.",
+                    e
+            );
+        }
+        return new ResponseStatusException(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "AI 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.",
+                e
+        );
+    }
 }

--- a/src/main/java/com/tripmoa/ai/dto/AiScheduleResponse.java
+++ b/src/main/java/com/tripmoa/ai/dto/AiScheduleResponse.java
@@ -1,45 +1,3 @@
-//package com.tripmoa.ai.dto;
-//
-//import lombok.Getter;
-//
-//import java.util.List;
-//
-///**
-// * AiScheduleResponse
-// * - Python → Spring 응답 DTO
-// * - AI가 생성한 일정 구조를 그대로 받는다
-// * 구조 반드시 Python 응답과 일치해야 함
-// */
-//@Getter
-//public class AiScheduleResponse {
-//
-//    //Day 단위 일정 리스트
-//    private List<DayPlan> days;
-//
-//    //DayPlan (하루 일정)
-//    @Getter
-//    public static class DayPlan {
-//        // 몇 번째 날인지
-//        private int day;
-//
-//        // 해당 날짜의 일정 리스트
-//        private List<Item> items;
-//    }
-//
-//    // Item 개별 일정
-//    @Getter
-//    public static class Item {
-//        //시간 (예: "09:00")
-//        private String time;
-//
-//        //일정 제목 (예: "경복궁 방문")
-//        private String title;
-//
-//        //상세 설명
-//        private String description;
-//    }
-//
-//}
 package com.tripmoa.ai.dto;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -51,6 +9,9 @@ import java.util.Map;
 
 /**
  * AiScheduleResponse
+ * - Python -> Spring 응답 DTO
+ * - AI가 생성한 일정 구조를 그래도 받음
+ * 구조가 반드시 Python 응답과 일치해야함
  * Python 응답 구조:
  * {
  *   "success": true,
@@ -85,6 +46,8 @@ public class AiScheduleResponse {
     public static class DayPlan {
         private int day;
         private List<Item> places;  // Python에서 "places" 필드로 옴
+        private List<String> pin_warnings;        // 고정 장소 시간 충돌 경고
+        private List<ExcludedPlace> excluded_places; // 용량 초과/시간대 제약으로 제외된 장소
 
         public void setDay(int day) {
             this.day = day;
@@ -100,5 +63,16 @@ public class AiScheduleResponse {
         private String description;
         private Double lat;
         private Double lng;
+        private Integer travel_minutes; //다음 장소까지 이동시간(분). ODsay 실측 값 또는 추정치
+        private Integer travel_payment;  // 다음 장소까지 대중교통 요금(원). ODsay 실측값이 있을 때만 존재
+        private Integer travel_transfer; // 다음 장소까지 환승 횟수. ODsay 실측값이 있을 때만 존재
+    }
+
+    @Getter
+    public static class ExcludedPlace {
+        private String name;
+        private String category;
+        private int day;
+        private String reason; // "capacity" | "morning_cafe"
     }
 }

--- a/src/main/java/com/tripmoa/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/tripmoa/global/config/RestTemplateConfig.java
@@ -9,8 +9,10 @@ import org.springframework.web.client.RestTemplate;
  * RestTemplateConfig
  *
  * - 외부 API 호출을 위한 RestTemplate Bean 설정
- * - 연결 타임아웃(5초) 및 응답 타임아웃(30초) 설정
+ * - 연결 타임아웃(5초) 및 응답 타임아웃(60초) 설정
  * - OCR, 외부 LLM 등 외부 서비스 호출 시 사용
+ * - AI 일정 생성이 ODsay API를 최대 20건까지 실제 호출할 수 있어서
+ *   기존 30초는 장소가 많은 일정에서 빠듯할 수 있어 60초로 상향
  */
 
 @Configuration
@@ -20,7 +22,7 @@ public class RestTemplateConfig {
     public RestTemplate restTemplate() {
         SimpleClientHttpRequestFactory f = new SimpleClientHttpRequestFactory();
         f.setConnectTimeout(5000);
-        f.setReadTimeout(30000);
+        f.setReadTimeout(60000);
         return new RestTemplate(f);
     }
 }

--- a/src/main/java/com/tripmoa/place/controller/PlaceController.java
+++ b/src/main/java/com/tripmoa/place/controller/PlaceController.java
@@ -56,8 +56,9 @@ public class PlaceController {
             @PathVariable Long placeId,
             @RequestBody PlaceUpdateRequest request
     ) {
-        // placeId만으로 tripId를 알 수 없어서 권한 체크는 서비스 레이어에서 처리
-        return ResponseEntity.ok(placeService.update(placeId, request));
+        // placeId로 장소를 먼저 조회해서 tripId를 얻은 뒤 권한 체크 (PlaceService 내부에서 처리)
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(placeService.update(placeId, userId, request));
     }
 
     // 장소 삭제 DELETE /api/places/{placeId}
@@ -65,8 +66,9 @@ public class PlaceController {
     public ResponseEntity<Void> delete(@AuthenticationPrincipal CustomUserDetails userDetails,
                                        @PathVariable Long placeId) {
 
-        // 삭제는 placeId만으로 처리 (PlaceService 내부에서 처리)
-        placeService.deletePlace(placeId);
+        // placeId로 장소를 먼저 조회해서 tripId를 얻은 뒤 권한 체크 (PlaceService 내부에서 처리)
+        Long userId = userDetails.getUser().getId();
+        placeService.deletePlace(placeId, userId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/tripmoa/place/domain/Place.java
+++ b/src/main/java/com/tripmoa/place/domain/Place.java
@@ -39,12 +39,8 @@ public class Place {
     @Column(length = 500)
     private String description;  // 추가: 장소 설명
 
-    // 사용자 장소 메모
-    private String memo;
-
-    // 카테고리, 메모 수정
-    public void update(String category, String memo) {
+    // 카테고리 수정
+    public void update(String category) {
         if (category != null) this.category = category;
-        if (memo != null) this.memo = memo;
     }
 }

--- a/src/main/java/com/tripmoa/place/dto/PlaceCreateRequest.java
+++ b/src/main/java/com/tripmoa/place/dto/PlaceCreateRequest.java
@@ -21,5 +21,4 @@ public class PlaceCreateRequest {
 
     private String address;
     private String description;
-    private String memo;
 }

--- a/src/main/java/com/tripmoa/place/dto/PlaceResponse.java
+++ b/src/main/java/com/tripmoa/place/dto/PlaceResponse.java
@@ -24,7 +24,6 @@ public class PlaceResponse {
 
     private String address;
     private String description;
-    private String memo;
 
     //Entity -> Dto 변환
     public static PlaceResponse from(Place place) {
@@ -37,7 +36,6 @@ public class PlaceResponse {
                 .lng(place.getLng())
                 .address(place.getAddress())
                 .description(place.getDescription())
-                .memo(place.getMemo())
                 .build();
     }
 }

--- a/src/main/java/com/tripmoa/place/dto/PlaceUpdateRequest.java
+++ b/src/main/java/com/tripmoa/place/dto/PlaceUpdateRequest.java
@@ -3,10 +3,9 @@ package com.tripmoa.place.dto;
 import lombok.Getter;
 
 /**
- * 장소 수정 요청 DTO (카테고리, 메모만 수정 가능)
+ * 장소 수정 요청 DTO (카테고리만 수정 가능)
  */
 @Getter
 public class PlaceUpdateRequest {
     private String category;
-    private String memo;
 }

--- a/src/main/java/com/tripmoa/place/service/PlaceService.java
+++ b/src/main/java/com/tripmoa/place/service/PlaceService.java
@@ -7,6 +7,7 @@ import com.tripmoa.place.dto.PlaceCreateRequest;
 import com.tripmoa.place.dto.PlaceResponse;
 import com.tripmoa.place.dto.PlaceUpdateRequest;
 import com.tripmoa.place.repository.PlaceRepository;
+import com.tripmoa.trip.service.TripPermissionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ import java.util.List;
 public class PlaceService {
 
     private final PlaceRepository placeRepository;
+    private final TripPermissionService tripPermissionService;
 
     // 장소 생성
     public PlaceResponse save(PlaceCreateRequest request) {
@@ -33,7 +35,6 @@ public class PlaceService {
                 .lng(request.getLng())
                 .address(request.getAddress())
                 .description(request.getDescription())
-                .memo(request.getMemo())
                 .build();
 
         return PlaceResponse.from(placeRepository.save(place));
@@ -47,19 +48,26 @@ public class PlaceService {
                 .toList();
     }
 
-    // 장소 카테고리/메모 수정
+    // 장소 카테고리 수정
     @Transactional
-    public PlaceResponse update(Long placeId, PlaceUpdateRequest request) {
+    public PlaceResponse update(Long placeId, Long userId, PlaceUpdateRequest request) {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
 
-        place.update(request.getCategory(), request.getMemo());
+        tripPermissionService.assertOwnerOrMember(place.getTripId(), userId);
+
+        place.update(request.getCategory());
 
         return PlaceResponse.from(place);
     }
 
     //장소 삭제
-    public void deletePlace(Long placeId) {
+    public void deletePlace(Long placeId, Long userId) {
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        tripPermissionService.assertOwnerOrMember(place.getTripId(), userId);
+
         placeRepository.deleteById(placeId);
     }
 }

--- a/src/main/java/com/tripmoa/schedule/domain/ScheduleItem.java
+++ b/src/main/java/com/tripmoa/schedule/domain/ScheduleItem.java
@@ -44,6 +44,15 @@ public class ScheduleItem {
     private Double lat;
     private Double lng;
 
+    // 다음 장소까지 이동시간 (분) - ODsay 실측값 또는 하버사인 추정치
+    private Integer travelMinutes;
+
+    // 다음 장소까지 대중교통 요금 (원) - ODsay 실측값이 있을 때만 존재
+    private Integer travelPayment;
+
+    // 다음 장소까지 환승 횟수 - ODsay 실측값이 있을 때만 존재
+    private Integer travelTransfer;
+
     // 노드 수정
     public void update(String time, String title, String description) {
         if (time != null) this.time = time;

--- a/src/main/java/com/tripmoa/schedule/dto/ExcludedPlaceResponse.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ExcludedPlaceResponse.java
@@ -1,0 +1,15 @@
+package com.tripmoa.schedule.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 일정 생성 시 용량 초과/시간대 제약으로 최종 일정에서 제외된 장소
+ */
+@Getter
+@Builder
+public class ExcludedPlaceResponse {
+    private String name;
+    private String category;
+    private String reason; // "capacity" | "morning_cafe"
+}

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleItemResponse.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleItemResponse.java
@@ -17,4 +17,7 @@ public class ScheduleItemResponse {
     private int orderIndex;
     private Double lat;
     private Double lng;
+    private Integer travelMinutes; // 다음 장소까지 이동시간(분)
+    private Integer travelPayment; // 다음 장소까지 대중교통 요금(원)
+    private Integer travelTransfer; // 다음 장소까지 환승 횟수
 }

--- a/src/main/java/com/tripmoa/schedule/dto/ScheduleResponse.java
+++ b/src/main/java/com/tripmoa/schedule/dto/ScheduleResponse.java
@@ -12,5 +12,7 @@ public class ScheduleResponse {
     private Long scheduleId;  // 추가: 클라이언트에서 day 식별용
     private int day;
     private List<ScheduleItemResponse> items;
+    private List<String> pinWarnings;             // 고정 장소 시간 충돌 경고 (생성 시에만 채워짐)
+    private List<ExcludedPlaceResponse> excludedPlaces; // 제외된 장소 (생성 시에만 채워짐)
 
 }

--- a/src/main/java/com/tripmoa/schedule/service/ScheduleMapper.java
+++ b/src/main/java/com/tripmoa/schedule/service/ScheduleMapper.java
@@ -1,61 +1,17 @@
-//package com.tripmoa.schedule.service;
-//
-//import com.tripmoa.ai.dto.AiScheduleResponse;
-//import com.tripmoa.schedule.domain.Schedule;
-//import com.tripmoa.schedule.domain.ScheduleItem;
-//
-//import java.util.ArrayList;
-//import java.util.List;
-//
-///**
-// * AI 응답 → DB Entity 변환
-// */
-//public class ScheduleMapper {
-//
-//    public static List<Schedule> toSchedules(Long tripId, AiScheduleResponse response){
-//
-//        List<Schedule> schedules = new ArrayList<>();
-//
-//        for(AiScheduleResponse.DayPlan day : response.getDays()) {
-//            schedules.add(
-//                    Schedule.builder()
-//                            .tripId(tripId)
-//                            .day(day.getDay())
-//                            .build()
-//            );
-//        }
-//        return schedules;
-//    }
-//
-//    public static List<ScheduleItem> toScheduleItems(Long scheduleId,
-//                                                     AiScheduleResponse.DayPlan dayPlan){
-//
-//        List<ScheduleItem> items = new ArrayList<>();
-//
-//        int index = 0;
-//        for(AiScheduleResponse.Item item : dayPlan.getItems()) {
-//            items.add(
-//                    ScheduleItem.builder()
-//                            .scheduleId(scheduleId)
-//                            .time(item.getTime())
-//                            .title(item.getTitle())
-//                            .description(item.getDescription())
-//                            .orderIndex(index++)
-//                            .build()
-//            );
-//        }
-//
-//        return items;
-//    }
-//}
 package com.tripmoa.schedule.service;
 
 import com.tripmoa.ai.dto.AiScheduleResponse;
 import com.tripmoa.schedule.domain.Schedule;
 import com.tripmoa.schedule.domain.ScheduleItem;
+import com.tripmoa.schedule.dto.ExcludedPlaceResponse;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+/**
+* AI 응답 → DB Entity 변환
+*/
 
 public class ScheduleMapper {
 
@@ -89,10 +45,33 @@ public class ScheduleMapper {
                             .description(item.getAddress() != null ? item.getAddress() : "")
                             .lat(item.getLat())
                             .lng(item.getLng())
+                            .travelMinutes(item.getTravel_minutes())
+                            .travelPayment(item.getTravel_payment())
+                            .travelTransfer(item.getTravel_transfer())
                             .orderIndex(index++)
                             .build()
             );
         }
         return items;
+    }
+
+    public static List<ExcludedPlaceResponse> toExcludedPlaces(AiScheduleResponse.DayPlan dayPlan) {
+        if (dayPlan.getExcluded_places() == null) return Collections.emptyList();
+
+        List<ExcludedPlaceResponse> result = new ArrayList<>();
+        for (AiScheduleResponse.ExcludedPlace e : dayPlan.getExcluded_places()) {
+            result.add(
+                    ExcludedPlaceResponse.builder()
+                            .name(e.getName())
+                            .category(e.getCategory())
+                            .reason(e.getReason())
+                            .build()
+            );
+        }
+        return result;
+    }
+
+    public static List<String> toPinWarnings(AiScheduleResponse.DayPlan dayPlan) {
+        return dayPlan.getPin_warnings() != null ? dayPlan.getPin_warnings() : Collections.emptyList();
     }
 }

--- a/src/main/java/com/tripmoa/schedule/service/ScheduleService.java
+++ b/src/main/java/com/tripmoa/schedule/service/ScheduleService.java
@@ -4,6 +4,7 @@ import com.tripmoa.ai.dto.AiScheduleRequest;
 import com.tripmoa.ai.dto.AiScheduleResponse;
 import com.tripmoa.schedule.domain.Schedule;
 import com.tripmoa.schedule.domain.ScheduleItem;
+import com.tripmoa.schedule.dto.ExcludedPlaceResponse;
 import com.tripmoa.schedule.dto.ScheduleItemResponse;
 import com.tripmoa.schedule.dto.ScheduleResponse;
 import com.tripmoa.schedule.repository.ScheduleItemRepository;
@@ -12,7 +13,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * DB 저장 + 조회 담당
@@ -48,16 +52,22 @@ public class ScheduleService {
         List<Schedule> savedSchedules = scheduleRepository.saveAll(schedules);
 
         // ScheduleItem 저장 — savedSchedules의 ID를 사용해야 scheduleId가 null이 아님
+        // + 생성 시에만 존재하는 pin 경고/제외 장소를 day별로 모아둠 (DB엔 저장 안 함)
         List<AiScheduleResponse.DayPlan> dayPlans = response.getItinerary().getDays();
+        Map<Integer, List<String>> pinWarningsByDay = new HashMap<>();
+        Map<Integer, List<ExcludedPlaceResponse>> excludedByDay = new HashMap<>();
         for (int i = 0; i < savedSchedules.size(); i++) {
             Schedule savedSchedule = savedSchedules.get(i);
             AiScheduleResponse.DayPlan dayPlan = dayPlans.get(i);
             List<ScheduleItem> items = ScheduleMapper.toScheduleItems(savedSchedule.getId(), dayPlan);
             scheduleItemRepository.saveAll(items);
+
+            pinWarningsByDay.put(dayPlan.getDay(), ScheduleMapper.toPinWarnings(dayPlan));
+            excludedByDay.put(dayPlan.getDay(), ScheduleMapper.toExcludedPlaces(dayPlan));
         }
 
         // 저장된 일정을 바로 반환 (Controller에서 프론트로 내려줌)
-        return getSchedules(tripId);
+        return getSchedules(tripId, pinWarningsByDay, excludedByDay);
     }
 
     /**
@@ -66,7 +76,14 @@ public class ScheduleService {
      */
     @Transactional(readOnly = true)
     public List<ScheduleResponse> getSchedules(Long tripId) {
+        return getSchedules(tripId, Map.of(), Map.of());
+    }
 
+    private List<ScheduleResponse> getSchedules(
+            Long tripId,
+            Map<Integer, List<String>> pinWarningsByDay,
+            Map<Integer, List<ExcludedPlaceResponse>> excludedByDay
+    ) {
         List<Schedule> schedules = scheduleRepository.findAllByTripId(tripId);
 
         return schedules.stream()
@@ -85,6 +102,9 @@ public class ScheduleService {
                                     .orderIndex(item.getOrderIndex())
                                     .lat(item.getLat())
                                     .lng(item.getLng())
+                                    .travelMinutes(item.getTravelMinutes())
+                                    .travelPayment(item.getTravelPayment())
+                                    .travelTransfer(item.getTravelTransfer())
                                     .build())
                             .toList();
 
@@ -92,6 +112,8 @@ public class ScheduleService {
                             .scheduleId(schedule.getId())
                             .day(schedule.getDay())
                             .items(items)
+                            .pinWarnings(pinWarningsByDay.getOrDefault(schedule.getDay(), Collections.emptyList()))
+                            .excludedPlaces(excludedByDay.getOrDefault(schedule.getDay(), Collections.emptyList()))
                             .build();
                 })
                 .toList();


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #127 

---

## 🛠️ 작업 내용 (What)
- PlaceService.update()/deletePlace()에 소유자·멤버 권한 체크 추가
- AiClient가 Python AI 서버의 에러 메시지를 그대로 파싱해 전달하도록 재작성
- RestTemplate readTimeout 30s → 60s 상향
- Place 관련 DTO/엔티티에서 memo 필드 전부 제거
- Schedule 응답에 pin_warnings/excluded_places 포함

---

## 🧭 작업 목적 (Why)
다른 사용자의 장소를 수정/삭제할 수 있는 권한 누락을 막고, AI 일정 생성 실패 시 원인을 알 수 없던 문제를 해결하기 위함. 메모는 일정 배정 후 새로고침하면 사라지는 반쪽짜리 기능이라 제거함.

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [ ] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [ ] 로컬 서버 실행
- [ ] API 테스트 (Postman/Swagger)
- [ ] 예외 케이스 확인

---

## ⚠️ 참고 사항
- memo DB 컬럼(`place.memo`)은 삭제하지 않고 애플리케이션 코드에서만 참조 제거함 (기존 데이터 보존)

---

## ✅ 체크리스트
- [ ] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료