### PR TITLE
[BE] fix: Docker 네트워크 환경에서 AI 서버 연동 및 DB 스키마 설정 수정

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -10,7 +10,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # JPA \uC124\uC815 (\uAC1C\uBC1C\uC6A9 : DDL \uB85C\uCEEC\uC5D0\uC11C \uAC1C\uC778 \uAD00\uB9AC)
 ################################
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=update
 
 ################################
 # JPA / Hibernate \uB85C\uADF8 \uC124\uC815 (\uD544\uC694\uC2DC true\uB85C \uC124\uC815)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ server.port=8080
 ################################
 cors.allowed-origins=http://localhost:3000,http://localhost:5173
 oauth2.redirect-url=http://localhost:3000
-ai.server.url=http://localhost:8000
+ai.server.url=http://python:8000
 
 ################################
 # \uC2E4\uD589 \uD504\uB85C\uD30C\uC77C


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #128 

---

## 🛠️ 작업 내용 (What)
- PlaceService.update()/deletePlace()에 소유자·멤버 권한 체크 추가
- AiClient가 Python AI 서버의 에러 메시지를 그대로 파싱해 전달하도록 재작성
- RestTemplate readTimeout 30s → 60s 상향
- Place 관련 DTO/엔티티에서 memo 필드 전부 제거
- Schedule 응답에 pin_warnings/excluded_places 포함

---

## 🧭 작업 목적 (Why)
다른 사용자의 장소를 수정/삭제할 수 있는 권한 누락을 막고, AI 일정 생성 실패 시 원인을 알 수 없던 문제를 해결하기 위함. 메모는 일정 배정 후 새로고침하면 사라지는 반쪽짜리 기능이라 제거함.

---

## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [ ] Repository
- [x] API 설계
- [ ] DB 스키마

---

## 🧪 테스트 방법
- [ ] 로컬 서버 실행
- [ ] API 테스트 (Postman/Swagger)
- [ ] 예외 케이스 확인

---

## ⚠️ 참고 사항
- memo DB 컬럼(`place.memo`)은 삭제하지 않고 애플리케이션 코드에서만 참조 제거함 (기존 데이터 보존)

---

## ✅ 체크리스트
- [ ] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료