### PR TITLE
[BE] feature: 여행 후기 백엔드 구현

### DIFF
--- a/src/main/java/com/tripmoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/tripmoa/global/exception/ErrorCode.java
@@ -139,6 +139,9 @@ public enum ErrorCode {
     // 일정 저장 관련에 추가
     SAVED_ITINERARY_NOT_FOUND(HttpStatus.NOT_FOUND, "STORY_404_004", "저장된 일정을 찾을 수 없습니다."),
 
+    // 리뷰 중복 작성 관련
+    REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "STORY_409_002", "이미 해당 여행의 후기를 작성했습니다."),
+
     // 댓글 관련
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "STORY_404_002", "commentId에 해당하는 댓글이 없습니다."),
     COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "STORY_403_003", "댓글을 수정할 권한이 없습니다."),

--- a/src/main/java/com/tripmoa/global/util/FastApiBadWordClient.java
+++ b/src/main/java/com/tripmoa/global/util/FastApiBadWordClient.java
@@ -1,0 +1,38 @@
+package com.tripmoa.global.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+public class FastApiBadWordClient {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    public FastApiBadWordClient(@Value("${ai.server.url}") String baseUrl) {
+        this.restTemplate = new RestTemplate();
+        this.baseUrl = baseUrl;
+    }
+
+    public boolean checkBadWord(String text) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> body = Map.of("text", text);
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                baseUrl + "/badword/check", entity, Map.class);
+
+        return (Boolean) response.getBody().get("isBlocked");
+    }
+}

--- a/src/main/java/com/tripmoa/story/controller/StoryController.java
+++ b/src/main/java/com/tripmoa/story/controller/StoryController.java
@@ -43,6 +43,17 @@ public class StoryController {
         return ResponseEntity.ok(storyService.getStorysByAuthor(userId));
     }
 
+    // 특정 여행의 리뷰 작성 여부 확인 (GET /api/stories/review-check?tripId={tripId})
+    @GetMapping("/review-check")
+    public ResponseEntity<Boolean> checkReviewExists(
+            @RequestParam Long tripId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        boolean exists = storyService.existsReviewByTripAndAuthor(tripId, userId);
+        return ResponseEntity.ok(exists);
+    }
+
     // 여행기 상세 조회 (GET /api/stories/{id})
     @GetMapping("/{id}")
     public ResponseEntity<StoryResponse> getStory(
@@ -144,4 +155,6 @@ public class StoryController {
         Long userId = userDetails.getUser().getId();
         return ResponseEntity.ok(savedItineraryService.getSavedItineraries(userId));
     }
+
+
 }

--- a/src/main/java/com/tripmoa/story/domain/Story.java
+++ b/src/main/java/com/tripmoa/story/domain/Story.java
@@ -83,8 +83,8 @@ public class Story {
     // 생성 시간
     private LocalDateTime createdAt;
 
-    // 수정 시간
-    private LocalDateTime updatedAt;
+    // 공개 여부
+    private Boolean isPublic = true;
 
     // 게시글 타입 (자유글 / 여행 후기)
     @Enumerated(EnumType.STRING)
@@ -94,7 +94,7 @@ public class Story {
     public Story(User author, Trip trip, String title, String description, String imageUrl,
                  String tags, String destination, String duration, String departureDate,
                  Integer transportation, Integer accommodation,
-                 Integer food, Integer attraction, Integer shopping, StoryType type) {
+                 Integer food, Integer attraction, Integer shopping, StoryType type, Boolean isPublic) {
         this.author = author;
         this.trip = trip;
         this.title = title;
@@ -113,7 +113,7 @@ public class Story {
         this.views = 0;
         this.type = type;
         this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        this.isPublic = isPublic;
     }
 
     // 여행기 수정
@@ -133,7 +133,6 @@ public class Story {
         this.food = food;
         this.attraction = attraction;
         this.shopping = shopping;
-        this.updatedAt = LocalDateTime.now();
     }
 
     // 조회수 증가
@@ -151,6 +150,16 @@ public class Story {
         if (this.likes > 0) {
             this.likes--;
         }
+    }
+
+    // 공개/비공개 변경
+    public void updateIsPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+
+    // 공개 여부 getter
+    public Boolean getIsPublic() {
+        return isPublic;
     }
 
     // 총 여행 경비 계산

--- a/src/main/java/com/tripmoa/story/dto/post/StoryRequest.java
+++ b/src/main/java/com/tripmoa/story/dto/post/StoryRequest.java
@@ -29,4 +29,8 @@ public class StoryRequest {
 
     private String type;
     private String status;
+
+    private Boolean isPublic = true;
+
+    private Long tripId;
 }

--- a/src/main/java/com/tripmoa/story/dto/post/StoryResponse.java
+++ b/src/main/java/com/tripmoa/story/dto/post/StoryResponse.java
@@ -47,9 +47,6 @@ public class StoryResponse {
     // 생성 시간
     private LocalDateTime createdAt;
 
-    // 수정 시간
-    private LocalDateTime updatedAt;
-
     // 여행 스타일 태그
     private String tags;
 
@@ -65,12 +62,19 @@ public class StoryResponse {
     // 출발 날짜
     private String departureDate;
 
+    // 연결된 여행 ID
+    private Long tripId;
+
     // 게시글 타입 (자유글 / 여행 후기)
     private String type;
 
     // 로그인 사용자의 좋아요 여부
     @JsonProperty("isLiked")
     private Boolean isLiked;
+
+    // 공개 여부
+    @JsonProperty("isPublic")
+    private Boolean isPublic;
 
     /* 작성자 정보 DTO */
     @Getter
@@ -175,14 +179,11 @@ public class StoryResponse {
                 .title(story.getTitle())
                 .description(story.getDescription())
                 .imageUrl(story.getImageUrl())
-
                 .author(author)
-
                 .likes(story.getLikes())
                 .views(story.getViews())
                 .comments(commentCount)
                 .createdAt(story.getCreatedAt())
-                .updatedAt(story.getUpdatedAt())
                 .tags(story.getTags())
                 .expenses(expenses)
                 .destination(story.getDestination())
@@ -190,6 +191,8 @@ public class StoryResponse {
                 .departureDate(story.getDepartureDate())
                 .type(story.getType() != null ? story.getType().name() : "FREE")
                 .isLiked(isLiked)
+                .isPublic(story.getIsPublic())
+                .tripId(story.getTrip() != null ? story.getTrip().getId() : null)
                 .build();
     }
 

--- a/src/main/java/com/tripmoa/story/dto/post/StoryUpdateRequest.java
+++ b/src/main/java/com/tripmoa/story/dto/post/StoryUpdateRequest.java
@@ -33,6 +33,9 @@ public class StoryUpdateRequest {
     // 출발 날짜
     private String departureDate;
 
+    // 공개 여부
+    private Boolean isPublic;
+
     // 여행 경비 항목
     private Integer transportation;  // 교통비
     private Integer accommodation;   // 숙박비

--- a/src/main/java/com/tripmoa/story/repository/StoryRepository.java
+++ b/src/main/java/com/tripmoa/story/repository/StoryRepository.java
@@ -4,6 +4,7 @@ import com.tripmoa.story.domain.Story;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.List;
+import com.tripmoa.story.enums.StoryType;
 
 /* 여행기 Repository
  - Story 엔티티의 DB 접근 담당 */
@@ -14,9 +15,18 @@ public interface StoryRepository extends JpaRepository<Story, Long> {
     // 특정 사용자가 작성한 여행기 목록 조회 (최신순)
     List<Story> findByAuthor_IdOrderByCreatedAtDesc(Long authorId);
 
+    // 전체 조회 (최신순)
     List<Story> findAllByOrderByCreatedAtDesc();
 
     // 태그 포함된 게시글 조회
     List<Story> findByTagsContaining(String tag);
 
+    // 특정 여행(tripId)에 대해 해당 작성자(authorId)의 리뷰가 이미 존재하는지 확인
+    boolean existsByTrip_IdAndAuthor_Id(Long tripId, Long authorId);
+
+    // 공개 글만 조회 (피드용) - REVIEW는 공개만, FREE는 다 보임
+    List<Story> findByIsPublicTrueOrTypeOrderByCreatedAtDesc(StoryType type);
+
+    // 태그 + 조건
+    List<Story> findByTagsContainingAndIsPublicTrueOrTagsContainingAndTypeOrderByCreatedAtDesc(String tag1, String tag2, StoryType type);
 }

--- a/src/main/java/com/tripmoa/story/service/StoryCommentService.java
+++ b/src/main/java/com/tripmoa/story/service/StoryCommentService.java
@@ -10,7 +10,7 @@ import com.tripmoa.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.tripmoa.global.util.BadWordFilter;
+import com.tripmoa.global.util.FastApiBadWordClient;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
 import java.util.List;
@@ -30,7 +30,7 @@ public class StoryCommentService {
 
     private final StoryCommentRepository storyCommentRepository;
     private final UserRepository userRepository;
-    private final BadWordFilter badWordFilter;
+    private final FastApiBadWordClient fastApiBadWordClient;
     private final StoryRepository storyRepository;
     private final ReportService reportService;
 
@@ -41,7 +41,7 @@ public class StoryCommentService {
     public CommentResponse createComment(Long storyId, CommentCreateRequest request, Long authorId) {
 
         // 욕설 필터 검사
-        if (badWordFilter.containsBadWord(request.getContent())) {
+        if (fastApiBadWordClient.checkBadWord(request.getContent())) {
             throw new BusinessException(ErrorCode.BAD_WORD_DETECTED);
         }
 
@@ -77,7 +77,7 @@ public class StoryCommentService {
     public CommentResponse updateComment(Long commentId, CommentCreateRequest request, Long authorId) {
 
         // 욕설 필터 검사
-        if (badWordFilter.containsBadWord(request.getContent())) {
+        if (fastApiBadWordClient.checkBadWord(request.getContent())) {
             throw new BusinessException(ErrorCode.BAD_WORD_DETECTED);
         }
 

--- a/src/main/java/com/tripmoa/story/service/StoryService.java
+++ b/src/main/java/com/tripmoa/story/service/StoryService.java
@@ -8,12 +8,14 @@ import com.tripmoa.story.enums.StoryType;
 import com.tripmoa.story.repository.StoryLikeRepository;
 import com.tripmoa.story.repository.StoryRepository;
 import com.tripmoa.story.repository.StoryCommentRepository;
+import com.tripmoa.trip.entity.Trip;
+import com.tripmoa.trip.repository.TripRepository;
 import com.tripmoa.user.entity.User;
 import com.tripmoa.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.tripmoa.global.util.BadWordFilter;
+import com.tripmoa.global.util.FastApiBadWordClient;
 import com.tripmoa.global.exception.BusinessException;
 import com.tripmoa.global.exception.ErrorCode;
 import java.util.List;
@@ -31,7 +33,8 @@ public class StoryService {
     private final UserRepository userRepository;
     private final StoryLikeRepository storyLikeRepository;
     private final StoryCommentRepository storyCommentRepository;
-    private final BadWordFilter badWordFilter;
+    private final FastApiBadWordClient fastApiBadWordClient;
+    private final TripRepository tripRepository;
 
     // 전체 여행기 목록 조회
     public List<StoryResponse> getStorys(Long userId, String tag) {
@@ -39,9 +42,15 @@ public class StoryService {
         List<Story> stories;
 
         if (tag == null) {
-            stories = storyRepository.findAllByOrderByCreatedAtDesc();
+            stories = storyRepository.findAllByOrderByCreatedAtDesc()
+                    .stream()
+                    .filter(s -> s.getType() == StoryType.FREE || Boolean.TRUE.equals(s.getIsPublic()))
+                    .collect(Collectors.toList());
         } else {
-            stories = storyRepository.findByTagsContaining("," + tag + ",");
+            stories = storyRepository.findByTagsContaining("," + tag + ",")
+                    .stream()
+                    .filter(s -> s.getType() == StoryType.FREE || Boolean.TRUE.equals(s.getIsPublic()))
+                    .collect(Collectors.toList());
         }
 
         return stories.stream()
@@ -83,13 +92,24 @@ public class StoryService {
     public StoryResponse createStory(StoryRequest request, Long authorId) {
 
         // 욕설 필터 검사
-        if (badWordFilter.containsBadWord(request.getTitle()) ||
-                badWordFilter.containsBadWord(request.getDescription())) {
+        if (fastApiBadWordClient.checkBadWord(request.getTitle()) ||
+                fastApiBadWordClient.checkBadWord(request.getDescription())) {
             throw new BusinessException(ErrorCode.BAD_WORD_DETECTED);
         }
 
         User author = userRepository.findById(authorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // Trip 연결
+        Trip trip = null;
+        if (request.getTripId() != null) {
+            trip = tripRepository.findById(request.getTripId()).orElse(null);
+
+            // 이미 해당 trip으로 작성된 리뷰 있는지 확인
+            if (storyRepository.existsByTrip_IdAndAuthor_Id(request.getTripId(), authorId)) {
+                throw new BusinessException(ErrorCode.REVIEW_ALREADY_EXISTS);
+            }
+        }
 
         String tags = request.getTagIds() != null
                 ? request.getTagIds().toString()
@@ -101,7 +121,7 @@ public class StoryService {
 
         Story story = new Story(
                 author,
-                null,
+                trip,
                 request.getTitle(),
                 request.getDescription(),
                 request.getImageUrl(),
@@ -114,7 +134,8 @@ public class StoryService {
                 request.getFood(),
                 request.getAttraction(),
                 request.getShopping(),
-                type
+                type,
+                request.getIsPublic()
 
         );
 
@@ -128,8 +149,8 @@ public class StoryService {
     public StoryResponse updateStory(Long id, StoryUpdateRequest request, Long authorId) {
 
         // 욕설 필터 검사
-        if (badWordFilter.containsBadWord(request.getTitle()) ||
-                badWordFilter.containsBadWord(request.getDescription())) {
+        if (fastApiBadWordClient.checkBadWord(request.getTitle()) ||
+                fastApiBadWordClient.checkBadWord(request.getDescription())) {
             throw new BusinessException(ErrorCode.BAD_WORD_DETECTED);
         }
 
@@ -155,6 +176,7 @@ public class StoryService {
                 request.getAttraction(),
                 request.getShopping()
         );
+        story.updateIsPublic(request.getIsPublic());
 
         User user = userRepository.findById(authorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -218,5 +240,10 @@ public class StoryService {
                     return StoryResponse.from(story, story.getAuthor(), true, commentCount);
                 })
                 .collect(Collectors.toList());
+    }
+
+    // 특정 여행의 리뷰 작성 여부 확인
+    public boolean existsReviewByTripAndAuthor(Long tripId, Long authorId) {
+        return storyRepository.existsByTrip_IdAndAuthor_Id(tripId, authorId);
     }
 }

--- a/src/main/java/com/tripmoa/trip/entity/Trip.java
+++ b/src/main/java/com/tripmoa/trip/entity/Trip.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import com.tripmoa.story.domain.Story;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -79,6 +80,11 @@ public class Trip {
     @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<TripMember> members = new ArrayList<>();
+
+    // Story 연관관계 추가
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Story> stories = new ArrayList<>();
 
     // === 메서드 ===
     @PrePersist


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #131 

---
## 🛠️ 작업 내용 (What)
- Story isPublic 컬럼 추가 (공개/비공개 설정)
- FastAPI CLOVA AI 금칙어 필터 연동
- 후기 중복 작성 방지 API 추가
- tripId 연결로 여행 계획과 후기 연동
- review-check API 추가 (GET /api/stories/review-check?tripId={tripId})

---
## 🧭 작업 목적 (Why)
여행 후기 공개/비공개 설정, 중복 작성 방지, AI 금칙어 필터링을 통한 커뮤니티 품질 향상

---
## 🧩 변경 범위
- [x] Controller
- [x] Service
- [x] Domain(Entity)
- [x] Repository
- [x] API 설계
- [x] DB 스키마

---
## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Swagger)
- [x] 예외 케이스 확인

---
## ⚠️ 참고 사항

**수정된 파일**
- `StoryService.java` - AI 금칙어 필터, isPublic, tripId 연동
- `StoryCommentService.java` - AI 금칙어 필터
- `StoryRequest.java` - isPublic, tripId 추가
- `StoryUpdateRequest.java` - isPublic 추가
- `StoryResponse.java` - isPublic, tripId 추가
- `StoryRepository.java` - isPublic 조회 메서드, tripId 중복 체크 메서드 추가
- `StoryController.java` - review-check API 추가
- `Story.java` - isPublic 컬럼 추가
- `ErrorCode.java` - REVIEW_ALREADY_EXISTS 추가
- `FastApiBadWordClient.java` - 새로 생성

**팀원 파일 수정 (확인 필요!)**
- `Trip.java` - Story 연관관계 추가 (@OneToMany)

**DB 변경 사항**
story 테이블에 is_public 컬럼 추가 필요
```sql
ALTER TABLE story ADD COLUMN is_public BOOLEAN DEFAULT TRUE;
```

---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [ ] API 명세 변경 시 공유 완료
