### PR TITLE
[BE] fix: 하드코딩 된 WebSocket 도메인 변경

### DIFF
--- a/src/main/java/com/tripmoa/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/tripmoa/chat/config/WebSocketConfig.java
@@ -23,10 +23,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         config.setApplicationDestinationPrefixes("/pub");
     }
 
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("http://localhost:*", "https://tripmoa.com")  // 배포 시 수정
+                .setAllowedOriginPatterns(allowedOrigins.split(","))
                 .withSockJS();
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #133 

---

## 🛠️ 작업 내용 (What)
- `WebSocketConfig`의 `setAllowedOriginPatterns()` 하드코딩 값 제거
- `cors.allowed-origins` 프로퍼티를 `@Value`로 주입받아 콤마 단위로 분리해 적용
- 실존하지 않는 도메인(`https://tripmoa.com`) 및 "배포 시 수정" TODO 주석 제거

```java
// AS-IS
registry.addEndpoint("/ws")
        .setAllowedOriginPatterns("http://localhost:*", "https://tripmoa.com")
        .withSockJS();

// TO-BE
registry.addEndpoint("/ws")
        .setAllowedOriginPatterns(allowedOrigins.split(","))
        .withSockJS();
```

---

## 🧭 작업 목적 (Why)
- 배포 도메인과 개발 환경 당시 설정한 도메인에 차이가 있어 수정함
- 도메인 변경·HTTPS 전환 시 코드 수정 없이 프로파일 설정만으로 대응 가능

---

## 🧩 변경 범위
- [ ] Controller
- [ ] Service
- [ ] Domain(Entity)
- [ ] Repository
- [ ] API 설계
- [ ] DB 스키마

> 해당 없음 — WebSocket 설정(`chat/config/WebSocketConfig.java`) 단일 파일 변경

---

## 🧪 테스트 방법
- [x] 로컬 서버 실행
- [x] API 테스트 (Postman/Swagger)
- [x] 예외 케이스 확인

**검증 내역**
1. `curl -i http://<도메인>/ws/info` → 200 응답 및 SockJS 정보 JSON 확인
2. 브라우저에서 채팅방 진입 → STOMP `CONNECTED` 프레임 수신 확인
3. 두 계정으로 동시 접속하여 메시지 실시간 송수신 확인
4. 허용 목록에 없는 오리진에서 핸드셰이크 시도 → 403으로 정상 거부되는지 확인 (보안 동작 유지)

---

## ⚠️ 참고 사항
- `cors.allowed-origins`에 값을 넣을 때 **콤마 뒤 공백을 넣지 말아 주세요.** `split(",")`만 수행하므로 공백이 포함되면 오리진 매칭에 실패합니다.
- 프론트엔드의 `useStompClient.ts` `WS_URL` 하드코딩은 이 PR 범위 밖입니다. 해당 수정 전까지는 배포 환경에서 채팅이 여전히 연결되지 않으니, 프론트 PR과 함께 배포되어야 실제 동작이 확인됩니다.
- 값 주입 방식이라 배포 시 `APP_ORIGIN` 환경변수 누락에 주의가 필요합니다. 누락되면 애플리케이션 기동 단계에서 바로 실패합니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature/refactor/bugfix 브랜치에서 작업
- [x] 불필요한 로그 제거
- [x] API 명세 변경 시 공유 완료